### PR TITLE
Add Caddy reverse proxy and fully automate domain + HTTPS deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,28 @@
 name: Deploy
 
-# Continuous deployment to the Contabo VPS.
+# Fully automated continuous deployment to the Contabo VPS.
 #
-# This runs ONLY after the CI workflow finishes successfully on `main`, so a
-# red build never reaches the server. It opens an SSH connection to the VPS and
-# runs the same update you would run by hand: pull the new code and rebuild the
-# Docker stack (with the antivirus profile). All persistent state lives on named
-# volumes, so the rebuild never touches accounts, files, shares or backups.
+# Trigger: runs ONLY after the CI workflow finishes successfully on `main`, so a
+# red build never reaches the server. The job then, with no manual steps:
+#   1. SSHes into the VPS,
+#   2. pulls the latest `main` and rebuilds the Docker stack (app + db + Caddy,
+#      plus ClamAV via the antivirus profile),
+#   3. serves the app on the configured domain with automatic HTTPS (Caddy +
+#      Let's Encrypt), and
+#   4. verifies the app reports healthy before declaring success.
+# All persistent state lives on named volumes, so redeploys never touch
+# accounts, files, shares or backups.
 #
 # Required repository secrets (Settings -> Secrets and variables -> Actions):
-#   DEPLOY_HOST     - VPS IP or hostname (e.g. drive.example.com)
+#   DEPLOY_HOST     - VPS IPv4 address (GitHub runners have no IPv6 route)
 #   DEPLOY_USER     - the deploy user on the VPS (e.g. deploy)
 #   DEPLOY_SSH_KEY  - the PRIVATE key whose public half is in the deploy
 #                     user's ~/.ssh/authorized_keys on the VPS
 #
-# See docs/DEPLOYMENT_CONTABO.md for the one-time server setup that creates the
-# deploy user and the SSH key referenced above.
+# Optional repository variables (override the defaults below without editing
+# this file): DRIVE_SITE_ADDRESS, DRIVE_CORS_ALLOW_ORIGINS.
+#
+# See docs/DEPLOYMENT_CONTABO.md for the one-time server setup.
 
 on:
   workflow_run:
@@ -23,7 +30,7 @@ on:
     types: [completed]
     branches: [main]
 
-# Never run two deploys at once; cancel an in-flight one if a newer build lands.
+# Never run two deploys at once; let an in-flight deploy finish.
 concurrency:
   group: deploy-production
   cancel-in-progress: false
@@ -39,23 +46,51 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          # Public address Caddy serves. A bare domain triggers automatic HTTPS.
+          # Override via a repo variable; defaults to the project's domain.
+          SITE_ADDRESS: ${{ vars.DRIVE_SITE_ADDRESS || 'personal-drive-io.com' }}
+          CORS_ORIGINS: ${{ vars.DRIVE_CORS_ALLOW_ORIGINS || 'https://personal-drive-io.com' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
           printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          # Trust the host on first contact (TOFU). For stronger security, replace
-          # this with a pinned entry: store the VPS host key as a secret and write
-          # it to ~/.ssh/known_hosts instead of scanning.
+          # Trust the host on first contact (TOFU). For stronger security, pin the
+          # VPS host key in a secret and write it to known_hosts instead.
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" 'bash -s' <<'REMOTE'
+          # Pass the public-address config into the remote shell environment so
+          # docker compose picks it up for ${DRIVE_SITE_ADDRESS} interpolation.
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DRIVE_SITE_ADDRESS='${SITE_ADDRESS}' DRIVE_CORS_ALLOW_ORIGINS='${CORS_ORIGINS}' bash -s" <<'REMOTE'
             set -euo pipefail
             cd ~/cloud-storage-system
+
+            # 1. Sync to the exact state of origin/main.
             git fetch origin main
             git reset --hard origin/main
-            # --profile antivirus brings up the ClamAV container alongside the app.
+
+            # 2. Build and (re)start the whole stack. Caddy reads
+            #    DRIVE_SITE_ADDRESS from the environment exported above and
+            #    obtains/renews a Let's Encrypt cert automatically for a domain.
+            export DRIVE_SITE_ADDRESS DRIVE_CORS_ALLOW_ORIGINS
             docker compose --profile antivirus up -d --build
-            # Reclaim disk from the previous image build (important on a small box).
+
+            # 3. Reclaim disk from the previous image build (small box).
             docker image prune -f
+
+            # 4. Verify the app actually came up before we call this a success.
+            ok=""
+            for i in $(seq 1 30); do
+              if curl -fsS http://127.0.0.1:8000/healthz >/dev/null 2>&1; then ok=1; break; fi
+              sleep 5
+            done
+            if [ -z "$ok" ]; then
+              echo "::error::App did not become healthy after deploy"
+              docker compose ps
+              docker compose logs --tail=80 app
+              exit 1
+            fi
+
+            echo "Deploy OK — app healthy. Public address: ${DRIVE_SITE_ADDRESS}"
             docker compose ps
           REMOTE

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,11 @@
+# Reverse proxy for the Personal Cloud Storage app.
+#
+# DRIVE_SITE_ADDRESS controls how the app is served:
+#   :80                  -> plain HTTP on the server's IP (default; no domain)
+#   drive.example.com    -> Caddy auto-provisions a Let's Encrypt HTTPS cert
+#
+# To switch to HTTPS later: point a DNS A record at the server, set
+# DRIVE_SITE_ADDRESS=yourdomain in .env, and redeploy. Nothing else changes.
+{$DRIVE_SITE_ADDRESS::80} {
+	reverse_proxy app:8000
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
-# Production deployment: the FastAPI app plus a dedicated PostgreSQL container,
-# each with its own named volume so data survives `docker compose down` and
-# image rebuilds. An optional ClamAV service can be enabled with the `antivirus`
-# profile: `docker compose --profile antivirus up -d`.
+# Production deployment: a Caddy reverse proxy in front of the FastAPI app plus
+# a dedicated PostgreSQL container, each with its own named volume so data
+# survives `docker compose down` and image rebuilds. Caddy is the only publicly
+# exposed service (ports 80/443); the app is reachable only on localhost and
+# through the Compose network. An optional ClamAV service can be enabled with
+# the `antivirus` profile: `docker compose --profile antivirus up -d`.
+#
+# Public address is controlled by DRIVE_SITE_ADDRESS (default ":80", plain HTTP
+# on the server IP). Set it to a domain (e.g. "drive.example.com") and Caddy
+# automatically provisions and renews a Let's Encrypt HTTPS certificate.
 
 services:
   db:
@@ -43,8 +49,26 @@ services:
     volumes:
       - blob_data:/data/blobs
       - backup_data:/data/backups
+    # Published on localhost only: external traffic must go through Caddy. The
+    # local bind keeps `curl localhost:8000/healthz` working (used by CI).
     ports:
-      - "${DRIVE_PORT:-8000}:8000"
+      - "127.0.0.1:${DRIVE_PORT:-8000}:8000"
+
+  caddy:
+    image: caddy:2
+    restart: unless-stopped
+    depends_on:
+      - app
+    environment:
+      # ":80" = plain HTTP on the server IP. Set to a domain for auto-HTTPS.
+      DRIVE_SITE_ADDRESS: ${DRIVE_SITE_ADDRESS:-:80}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
 
   clamav:
     image: clamav/clamav:1.4
@@ -64,3 +88,5 @@ volumes:
   blob_data:
   backup_data:
   clamav_data:
+  caddy_data:
+  caddy_config:

--- a/docs/DEPLOYMENT_CONTABO.md
+++ b/docs/DEPLOYMENT_CONTABO.md
@@ -145,25 +145,31 @@ stack and is the only publicly exposed service: the app itself is bound to
 localhost and reached only through Caddy. Data lives in the `db_data`,
 `blob_data` and `backup_data` volumes.
 
-## 6. How the app is served (Caddy + DRIVE_SITE_ADDRESS)
+## 6. How the app is served (Caddy + HTTPS)
 
 Caddy runs as a container (defined in `docker-compose.yml`, config in
-`Caddyfile`) and publishes ports 80/443. What it serves is controlled by one
-variable, `DRIVE_SITE_ADDRESS`:
+`Caddyfile`) and publishes ports 80/443. What it serves is controlled by
+`DRIVE_SITE_ADDRESS`. **The deploy pipeline sets this automatically** (see
+`.github/workflows/deploy.yml`), so a normal deploy already serves the app on the
+project domain over HTTPS — no manual step.
 
-- **No domain (default):** leave it unset (or `:80`). The app is served over
-  **plain HTTP on the server IP** — `http://<vps-ip>`. Good for testing.
-  > ⚠️ Plain HTTP sends login passwords in cleartext. Fine for a quick personal
-  > trial; add a domain (below) before relying on it.
-- **With a domain:** point a DNS A record at the VPS, then set the domain and
-  redeploy — Caddy auto-provisions and renews a Let's Encrypt certificate:
+- **Default (pipeline):** the workflow injects `DRIVE_SITE_ADDRESS` (the project
+  domain) and the matching CORS origin, and Caddy **auto-provisions and renews a
+  Let's Encrypt certificate**. To change the domain, set a repository *variable*
+  `DRIVE_SITE_ADDRESS` (and `DRIVE_CORS_ALLOW_ORIGINS`) — no workflow edit needed.
+- **The one external prerequisite is DNS:** a DNS **A record** for the domain
+  must point at the VPS IPv4. Caddy validates the domain over port 80, so the
+  cert is issued once DNS resolves (it retries automatically until then).
+- **Manual / no-pipeline deploys:** put the same values in `.env` instead:
   ```bash
-  echo "DRIVE_SITE_ADDRESS=drive.example.com" >> .env
-  echo "DRIVE_CORS_ALLOW_ORIGINS=https://drive.example.com" >> .env
+  echo "DRIVE_SITE_ADDRESS=personal-drive-io.com" >> .env
+  echo "DRIVE_CORS_ALLOW_ORIGINS=https://personal-drive-io.com" >> .env
   docker compose --profile antivirus up -d
   ```
-  `https://drive.example.com` now serves the app, no host-level web server
-  needed.
+- **No domain at all:** leave it unset; Caddy falls back to `:80` and serves
+  plain HTTP on the server IP (`http://<vps-ip>`).
+  > ⚠️ Plain HTTP sends login passwords in cleartext — use a domain for anything
+  > beyond a quick trial.
 
 ## 7. Firewall
 

--- a/docs/DEPLOYMENT_CONTABO.md
+++ b/docs/DEPLOYMENT_CONTABO.md
@@ -140,40 +140,35 @@ docker compose ps
 ```
 
 The **first ClamAV start downloads virus definitions (a few minutes)** before it
-reports healthy. The app is published on `http://<vps-ip>:8000`. Open it,
-register the first account, upload a file to confirm. Data lives in the
-`db_data`, `blob_data` and `backup_data` volumes.
+reports healthy. A **Caddy reverse proxy** comes up automatically as part of the
+stack and is the only publicly exposed service: the app itself is bound to
+localhost and reached only through Caddy. Data lives in the `db_data`,
+`blob_data` and `backup_data` volumes.
 
-## 6. HTTPS with Caddy
+## 6. How the app is served (Caddy + DRIVE_SITE_ADDRESS)
 
-Run Caddy on the host to terminate TLS (the app speaks plain HTTP behind it) and
-get automatic Let's Encrypt certificates. Requires the DNS A record from step 1.
+Caddy runs as a container (defined in `docker-compose.yml`, config in
+`Caddyfile`) and publishes ports 80/443. What it serves is controlled by one
+variable, `DRIVE_SITE_ADDRESS`:
 
-```bash
-sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-sudo apt-get update && sudo apt-get install -y caddy
-```
-
-Put this in `/etc/caddy/Caddyfile`:
-
-```
-drive.example.com {
-    reverse_proxy 127.0.0.1:8000
-}
-```
-
-```bash
-sudo systemctl reload caddy
-```
-
-`https://drive.example.com` now serves the app.
+- **No domain (default):** leave it unset (or `:80`). The app is served over
+  **plain HTTP on the server IP** — `http://<vps-ip>`. Good for testing.
+  > ⚠️ Plain HTTP sends login passwords in cleartext. Fine for a quick personal
+  > trial; add a domain (below) before relying on it.
+- **With a domain:** point a DNS A record at the VPS, then set the domain and
+  redeploy — Caddy auto-provisions and renews a Let's Encrypt certificate:
+  ```bash
+  echo "DRIVE_SITE_ADDRESS=drive.example.com" >> .env
+  echo "DRIVE_CORS_ALLOW_ORIGINS=https://drive.example.com" >> .env
+  docker compose --profile antivirus up -d
+  ```
+  `https://drive.example.com` now serves the app, no host-level web server
+  needed.
 
 ## 7. Firewall
 
 Contabo VPSes have **no cloud firewall by default**, so configure `ufw` on the
-host. Allow SSH + HTTP + HTTPS and block direct access to port 8000:
+host. Allow SSH + HTTP + HTTPS:
 
 ```bash
 sudo ufw allow OpenSSH
@@ -182,8 +177,9 @@ sudo ufw allow 443/tcp
 sudo ufw enable
 ```
 
-`ufw` blocks everything not allowed, so 8000 is now reachable only from
-localhost (where Caddy talks to it) — exactly what you want.
+Port 8000 is already bound to localhost only (see `docker-compose.yml`), so the
+app is never directly reachable from outside — all traffic goes through Caddy on
+80/443. `ufw` then blocks anything else.
 
 ## 8. Off-site backups
 


### PR DESCRIPTION
## What this does

Makes the Contabo deployment fully hands-off: after merging, every push to `main` builds, deploys, and serves the app over HTTPS at the project domain with zero manual server steps.

### Changes
- **Caddy reverse proxy** added to `docker-compose.yml` (publishes 80/443, proxies to the app). The app port is now bound to `127.0.0.1` only, so Caddy is the sole public entry point.
- **`Caddyfile`** driven by `DRIVE_SITE_ADDRESS` — a bare domain triggers automatic Let's Encrypt HTTPS; defaults to `:80` (plain HTTP) when no domain is set.
- **Deploy pipeline automation** (`.github/workflows/deploy.yml`):
  - injects `DRIVE_SITE_ADDRESS` / `DRIVE_CORS_ALLOW_ORIGINS` (default to the project domain, overridable via repo variables) so Caddy obtains/renews the TLS cert with no manual `.env` editing,
  - **verifies the app reports healthy** after `docker compose up` before declaring the deploy a success.
- **`docs/DEPLOYMENT_CONTABO.md`** updated to document the automated domain/HTTPS flow; DNS is the only remaining external prerequisite.
- Fixes the retired `clamav/clamav:1.3` image tag (→ `1.4`).

### One external prerequisite
A DNS **A record** for `personal-drive-io.com` → the VPS IPv4 must exist. Caddy validates over port 80 and issues the cert once DNS resolves (it retries automatically until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ)_