### PR TITLE
Fix container DNS so Caddy can obtain HTTPS certificates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,14 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    # Use public resolvers for outbound lookups (e.g. Let's Encrypt's ACME API).
+    # Without this, a host running systemd-resolved hands the container a
+    # 127.0.0.53 stub resolver that doesn't exist inside the container, so cert
+    # issuance fails. Service names (app, db) still resolve via Docker's embedded
+    # DNS on the Compose network.
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
@@ -74,6 +82,10 @@ services:
     image: clamav/clamav:1.4
     restart: unless-stopped
     profiles: ["antivirus"]
+    # ClamAV's freshclam needs working outbound DNS to fetch virus definitions.
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     volumes:
       - clamav_data:/var/lib/clamav
     healthcheck:

--- a/docs/DEPLOYMENT_CONTABO.md
+++ b/docs/DEPLOYMENT_CONTABO.md
@@ -39,6 +39,8 @@ antivirus workload:
   separately-billed **Object Storage** add-on is **not** app storage — the app
   writes uploads to the local disk, never to an S3 bucket. Object Storage is
   still worth adding as the off-site **backup** target (see step 8).
+  > For reference, a Storage VPS 20 exposes roughly **~387 GB usable** on `/`
+  > (check yours with `df -h /`); that local disk is your entire file capacity.
 - **Image: Ubuntu 24.04 LTS (64-bit).**
 - **Region:** pick the datacenter closest to you.
 - **Login:** set an SSH key if offered; otherwise Contabo emails you a **root

--- a/docs/DEPLOYMENT_CONTABO.md
+++ b/docs/DEPLOYMENT_CONTABO.md
@@ -282,3 +282,49 @@ docker compose exec app python -m app.cli verify-backup -i /data/backups/<bundle
 **HDD note:** these Storage VPS plans are spinning disk. For low traffic that is
 fine; the only HDD-sensitive part is PostgreSQL under heavy concurrency, which a
 personal/low-traffic drive will not hit.
+
+## 11. Troubleshooting
+
+### Caddy can't get an HTTPS certificate (DNS / systemd-resolved)
+
+Symptom — `docker compose logs caddy` shows ACME failing with:
+
+```
+lookup acme-v02.api.letsencrypt.org on 127.0.0.53:53: ... connection refused
+```
+
+Cause: Ubuntu runs **systemd-resolved**, whose stub resolver lives at
+`127.0.0.53`. That address only exists on the host, not inside a container, so
+the container can't resolve anything externally and cert issuance fails.
+
+The Compose file already pins public resolvers (`dns: [1.1.1.1, 8.8.8.8]`) on the
+`caddy` and `clamav` services, which fixes this for normal deploys. If you still
+hit it (e.g. other containers, or an older daemon), fix it globally at the Docker
+daemon level:
+
+```bash
+echo '{"dns": ["1.1.1.1", "8.8.8.8"]}' | sudo tee /etc/docker/daemon.json
+sudo systemctl restart docker
+cd ~/cloud-storage-system
+docker compose --profile antivirus up -d
+docker compose logs -f caddy        # watch the cert get issued
+```
+
+### "Site doesn't load" but the deploy succeeded
+
+The deploy health check probes the **app** (`localhost:8000`), so it can go green
+while **Caddy** (the public entry point) is still failing — almost always the DNS
+issue above, or a missing/late DNS A record for your domain. Check
+`docker compose logs caddy`, confirm `dig +short <domain>` returns the VPS IP, and
+make sure ports 80/443 are open and published (`docker compose ps` should show
+`0.0.0.0:80->80/tcp` on caddy).
+
+### Port 80/443 "address already in use"
+
+A host web server (often a previously apt-installed Caddy) is holding the port.
+Find and disable it, then redeploy:
+
+```bash
+sudo ss -tlnp 'sport = :80'
+sudo systemctl disable --now caddy   # or nginx / apache2
+```


### PR DESCRIPTION
## Problem

After deploy, the site didn't load. The deploy went green (its health check probes the app on `localhost:8000`), but **Caddy could not obtain a Let's Encrypt certificate**:

```
lookup acme-v02.api.letsencrypt.org on 127.0.0.53:53: ... connection refused
```

`127.0.0.53` is the host's **systemd-resolved** stub resolver, which doesn't exist inside a container — so the Caddy container couldn't resolve any external name, ACME failed, and nothing was served on 443. (ClamAV happened to work only because it was created earlier when the resolver was still usable.)

## Fix

- **`docker-compose.yml`:** pin public resolvers `dns: [1.1.1.1, 8.8.8.8]` on the `caddy` and `clamav` services (the ones that make outbound requests). Service discovery for `app`/`db` still works via Docker's embedded DNS on the Compose network.
- **`docs/DEPLOYMENT_CONTABO.md`:** add a Troubleshooting section covering the systemd-resolved DNS issue (incl. the global `/etc/docker/daemon.json` fix), the "site doesn't load but deploy succeeded" case, and host port-80 conflicts.

## Immediate host fix (applied separately on the running VPS)

```bash
echo '{"dns": ["1.1.1.1", "8.8.8.8"]}' | sudo tee /etc/docker/daemon.json
sudo systemctl restart docker
docker compose --profile antivirus up -d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ)_