### PR TITLE
Fix uploads behind HTTPS proxy (mixed-content blocked PUT)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       DRIVE_SECRET_KEY: ${DRIVE_SECRET_KEY:?Set DRIVE_SECRET_KEY in a .env file}
       DRIVE_STORAGE_DIR: /data/blobs
       DRIVE_BACKUP_DIR: /data/backups
+      # Trust Caddy's X-Forwarded-Proto/Host so the app builds https:// signed
+      # blob URLs (request.base_url). Without this, uploads/downloads use http://
+      # and the browser blocks them as mixed content on an HTTPS page. Safe to
+      # trust all: only Caddy can reach this port (bound to localhost + network).
+      FORWARDED_ALLOW_IPS: "*"
       DRIVE_CORS_ALLOW_ORIGINS: ${DRIVE_CORS_ALLOW_ORIGINS:-*}
       # Per-user quota in bytes (0 = unlimited).
       DRIVE_USER_QUOTA_BYTES: ${DRIVE_USER_QUOTA_BYTES:-0}


### PR DESCRIPTION
## Problem

Uploads fail with "Uploaded 0 file(s), 1 failed". Browser console:

```
Mixed Content: The page at 'https://personal-drive-io.com/' was loaded over HTTPS,
but requested an insecure XMLHttpRequest endpoint
'http://personal-drive-io.com/v2/blob/upload?token=...'. This request has been blocked.
```

The app builds signed blob upload/download URLs from `request.base_url` (`backend/app/blob_links.py`). Behind Caddy (plain HTTP internally), uvicorn doesn't trust `X-Forwarded-Proto` because the proxy peer isn't `127.0.0.1`, so `request.base_url` resolves to `http://…`. The browser then blocks the upload PUT as mixed content on the HTTPS page.

## Fix

Set `FORWARDED_ALLOW_IPS=*` on the `app` service so uvicorn honors Caddy's forwarded headers and emits `https://` signed URLs. Safe to trust all forwarded IPs here: the app port is bound to localhost and only reachable through Caddy on the Compose network.

## After deploy
Re-test an upload; the `upload` request URL in DevTools should now be `https://`. Note: files that failed earlier may now `409` (their metadata was created before the byte upload was blocked) — delete the leftover entry and re-upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ)_