### PR TITLE
Serve www.personal-drive-io.com alongside the apex domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,11 @@ jobs:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-          # Public address Caddy serves. A bare domain triggers automatic HTTPS.
-          # Override via a repo variable; defaults to the project's domain.
-          SITE_ADDRESS: ${{ vars.DRIVE_SITE_ADDRESS || 'personal-drive-io.com' }}
-          CORS_ORIGINS: ${{ vars.DRIVE_CORS_ALLOW_ORIGINS || 'https://personal-drive-io.com' }}
+          # Public address(es) Caddy serves. Bare domains trigger automatic
+          # HTTPS; space-separated to serve both apex and www. Override via repo
+          # variables. CORS origins are comma-separated (parsed by the app).
+          SITE_ADDRESS: ${{ vars.DRIVE_SITE_ADDRESS || 'personal-drive-io.com www.personal-drive-io.com' }}
+          CORS_ORIGINS: ${{ vars.DRIVE_CORS_ALLOW_ORIGINS || 'https://personal-drive-io.com,https://www.personal-drive-io.com' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,8 +1,10 @@
 # Reverse proxy for the Personal Cloud Storage app.
 #
 # DRIVE_SITE_ADDRESS controls how the app is served:
-#   :80                  -> plain HTTP on the server's IP (default; no domain)
-#   drive.example.com    -> Caddy auto-provisions a Let's Encrypt HTTPS cert
+#   :80                           -> plain HTTP on the server's IP (default)
+#   example.com                   -> auto Let's Encrypt HTTPS for one domain
+#   example.com www.example.com   -> serve (and get certs for) both; each domain
+#                                    needs its own DNS A record at the server
 #
 # To switch to HTTPS later: point a DNS A record at the server, set
 # DRIVE_SITE_ADDRESS=yourdomain in .env, and redeploy. Nothing else changes.


### PR DESCRIPTION
Superseded by #34 (same change, moved to the dedicated `claude/serve-www-domain` branch). Closing as duplicate.