### PR TITLE
Clean up partial uploads + cascade folder delete

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -10,6 +10,7 @@ Usage::
     python -m app.cli backup [--output-dir DIR]
     python -m app.cli restore --input backup-YYYYmmdd-HHMMSS.tar.gz
     python -m app.cli verify-backup --input <bundle>
+    python -m app.cli cleanup-partial-uploads [--older-than-hours N] [--dry-run]
 """
 
 from __future__ import annotations
@@ -19,6 +20,8 @@ import sys
 from pathlib import Path
 
 from . import backup as backup_mod
+from . import maintenance
+from .config import settings
 from .database import init_db
 from .dbio import export_db, import_db
 
@@ -48,6 +51,20 @@ def main(argv: list[str] | None = None) -> int:
     verify_cmd = sub.add_parser("verify-backup", help="Verify a backup bundle checksum")
     verify_cmd.add_argument("--input", "-i", required=True)
 
+    cleanup_cmd = sub.add_parser(
+        "cleanup-partial-uploads",
+        help="Delete never-finalized ('pending') uploads and their leftover bytes",
+    )
+    cleanup_cmd.add_argument(
+        "--older-than-hours",
+        type=int,
+        default=settings.partial_upload_max_age_hours,
+        help="Only remove pending uploads older than this many hours (default: %(default)s)",
+    )
+    cleanup_cmd.add_argument(
+        "--dry-run", action="store_true", help="List what would be removed without deleting"
+    )
+
     args = parser.parse_args(argv)
 
     if args.command == "init":
@@ -69,6 +86,14 @@ def main(argv: list[str] | None = None) -> int:
         ok = backup_mod.verify(Path(args.input))
         print("OK" if ok else "CORRUPT")
         return 0 if ok else 1
+    elif args.command == "cleanup-partial-uploads":
+        removed = maintenance.run_cleanup_partial_uploads(
+            args.older_than_hours, dry_run=args.dry_run
+        )
+        for file_id, filename in removed:
+            print(f"  {file_id}  {filename}")
+        verb = "Would remove" if args.dry_run else "Removed"
+        print(f"{verb} {len(removed)} partial upload(s) older than {args.older_than_hours}h")
     return 0
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,10 @@ class Settings(BaseSettings):
     backup_retention: int = 10
     maintenance_interval_minutes: int = 60
     enable_scheduler: bool = True
+    # Abandoned ("pending", never-finalized) uploads older than this are purged
+    # by the housekeeping sweep. 0 disables auto-cleanup. On demand via the CLI:
+    # `python -m app.cli cleanup-partial-uploads`.
+    partial_upload_max_age_hours: int = 24
 
     # Antivirus (ClamAV over TCP); disabled by default
     clamav_enabled: bool = False

--- a/backend/app/maintenance.py
+++ b/backend/app/maintenance.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from datetime import datetime, timedelta
 
 from sqlalchemy import delete, select
 
 from . import backup, storage
 from .config import settings
 from .database import SessionLocal
-from .models import ArchiveJob, IdempotencyRecord, PublicLink, Share
+from .models import ArchiveJob, File, IdempotencyRecord, PublicLink, Share
 from .utils import now_utc
 
 logger = logging.getLogger("maintenance")
@@ -50,16 +51,64 @@ def cleanup(db) -> dict[str, int]:
         delete(IdempotencyRecord).where(IdempotencyRecord.expires_at < now)
     ).rowcount or 0
 
+    max_age_hours = settings.partial_upload_max_age_hours
+    if max_age_hours > 0:
+        counts["partial_uploads"] = _delete_stale_pending(db, now - timedelta(hours=max_age_hours))
+    else:
+        counts["partial_uploads"] = 0
+
     db.commit()
     if any(counts.values()):
         logger.info("cleanup removed %s", counts)
     return counts
 
 
+def _stale_pending(db, cutoff: datetime) -> list[File]:
+    """Never-finalized uploads (status 'pending') created before ``cutoff``."""
+    return db.execute(
+        select(File).where(File.status == "pending", File.created_at < cutoff)
+    ).scalars().all()
+
+
+def _delete_stale_pending(db, cutoff: datetime) -> int:
+    """Delete stale pending uploads and any bytes already written. Does not
+    commit (the caller does, alongside the rest of the sweep)."""
+    stale = _stale_pending(db, cutoff)
+    for file in stale:
+        if file.storage_key:
+            storage.delete(file.storage_key)
+        db.delete(file)
+    return len(stale)
+
+
 def run_cleanup() -> dict[str, int]:
     db = SessionLocal()
     try:
         return cleanup(db)
+    finally:
+        db.close()
+
+
+def run_cleanup_partial_uploads(
+    older_than_hours: int, dry_run: bool = False
+) -> list[tuple[str, str]]:
+    """On-demand cleanup of abandoned uploads (CLI entry point).
+
+    Returns the ``(file_id, filename)`` pairs that were removed (or, with
+    ``dry_run``, that would be removed).
+    """
+    db = SessionLocal()
+    try:
+        cutoff = now_utc() - timedelta(hours=max(0, older_than_hours))
+        stale = _stale_pending(db, cutoff)
+        removed = [(f.id, f.filename) for f in stale]
+        if not dry_run and stale:
+            for file in stale:
+                if file.storage_key:
+                    storage.delete(file.storage_key)
+                db.delete(file)
+            db.commit()
+        return removed
     finally:
         db.close()
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -43,3 +43,44 @@ def test_cli_verify_corrupt_returns_nonzero(client, tmp_path):
 def test_cli_requires_subcommand(client):
     with pytest.raises(SystemExit):
         main([])
+
+
+def test_cli_cleanup_partial_uploads(client, capsys):
+    from app.database import SessionLocal
+    from app.models import File
+    from app.utils import now_utc
+
+    token, user_id, _ = register_and_login(client)
+    db = SessionLocal()
+    try:
+        from datetime import timedelta
+
+        stale = File(
+            owner_id=user_id, owner_email="o@o.com", filename="ghost.bin",
+            parent_folder_id="root", content_type="application/octet-stream",
+            size=0, status="pending", storage_key="",
+            created_at=now_utc() - timedelta(hours=48),
+        )
+        db.add(stale)
+        db.commit()
+        stale_id = stale.id
+    finally:
+        db.close()
+
+    # Dry-run keeps the row.
+    assert main(["cleanup-partial-uploads", "--dry-run"]) == 0
+    assert "Would remove 1" in capsys.readouterr().out
+    db = SessionLocal()
+    try:
+        assert db.get(File, stale_id) is not None
+    finally:
+        db.close()
+
+    # Real run removes it.
+    assert main(["cleanup-partial-uploads"]) == 0
+    assert "Removed 1" in capsys.readouterr().out
+    db = SessionLocal()
+    try:
+        assert db.get(File, stale_id) is None
+    finally:
+        db.close()

--- a/backend/tests/test_maintenance.py
+++ b/backend/tests/test_maintenance.py
@@ -2,10 +2,28 @@ from datetime import timedelta
 
 from conftest import register_and_login, upload_file
 
+from app import storage
 from app.database import SessionLocal
-from app.maintenance import cleanup
-from app.models import ArchiveJob, IdempotencyRecord, PublicLink, Share
+from app.maintenance import cleanup, run_cleanup_partial_uploads
+from app.models import ArchiveJob, File, IdempotencyRecord, PublicLink, Share
 from app.utils import now_utc
+
+
+def _make_file(db, user_id, *, name, status, age_hours, storage_key="") -> str:
+    file = File(
+        owner_id=user_id,
+        owner_email="o@o.com",
+        filename=name,
+        parent_folder_id="root",
+        content_type="application/octet-stream",
+        size=0,
+        status=status,
+        storage_key=storage_key,
+        created_at=now_utc() - timedelta(hours=age_hours),
+    )
+    db.add(file)
+    db.commit()
+    return file.id
 
 
 def test_cleanup_removes_expired_rows(client):
@@ -60,3 +78,65 @@ def test_cleanup_keeps_active_rows(client):
     finally:
         db.close()
     assert counts["public_links"] == 0
+
+
+def test_cleanup_removes_stale_pending_uploads(client):
+    token, user_id, _ = register_and_login(client)
+    # A finalized upload that should never be touched.
+    ready_id = upload_file(client, token, "keep.txt")
+
+    # Stale pending upload with bytes already on disk.
+    key = storage.file_key(user_id, "abandoned-id", "ghost.bin")
+    storage.open_write(key).write_bytes(b"partial bytes")
+
+    db = SessionLocal()
+    try:
+        stale_id = _make_file(db, user_id, name="ghost.bin", status="pending",
+                              age_hours=48, storage_key=key)
+        recent_id = _make_file(db, user_id, name="inflight.bin", status="pending",
+                               age_hours=1)
+    finally:
+        db.close()
+
+    db = SessionLocal()
+    try:
+        counts = cleanup(db)
+    finally:
+        db.close()
+
+    assert counts["partial_uploads"] == 1
+    db = SessionLocal()
+    try:
+        assert db.get(File, stale_id) is None       # old pending removed
+        assert db.get(File, recent_id) is not None  # within 24h grace, kept
+        assert db.get(File, ready_id) is not None    # finalized never touched
+    finally:
+        db.close()
+    assert not storage.exists(key)                   # leftover bytes removed
+
+
+def test_run_cleanup_partial_uploads_dry_run(client):
+    token, user_id, _ = register_and_login(client)
+    db = SessionLocal()
+    try:
+        fid = _make_file(db, user_id, name="abandoned.bin", status="pending", age_hours=48)
+    finally:
+        db.close()
+
+    # Dry run reports the row but does not delete it.
+    reported = run_cleanup_partial_uploads(0, dry_run=True)
+    assert any(rid == fid for rid, _ in reported)
+    db = SessionLocal()
+    try:
+        assert db.get(File, fid) is not None
+    finally:
+        db.close()
+
+    # Real run removes it.
+    removed = run_cleanup_partial_uploads(0)
+    assert any(rid == fid for rid, _ in removed)
+    db = SessionLocal()
+    try:
+        assert db.get(File, fid) is None
+    finally:
+        db.close()

--- a/docs/DEPLOYMENT_CONTABO.md
+++ b/docs/DEPLOYMENT_CONTABO.md
@@ -279,6 +279,25 @@ docker compose exec app python -m app.cli backup
 docker compose exec app python -m app.cli verify-backup -i /data/backups/<bundle>.tar.gz
 ```
 
+### Cleaning up partial uploads
+
+An upload that never finishes (the browser dies, or the byte PUT is blocked)
+leaves a `pending` file record — it clutters the drive and can cause "name
+already exists" (409) errors on retry. The housekeeping sweep purges `pending`
+uploads older than `DRIVE_PARTIAL_UPLOAD_MAX_AGE_HOURS` (default 24, set to 0 to
+disable). To clean up on demand:
+
+```bash
+# preview what would be removed (no changes)
+docker compose exec app python -m app.cli cleanup-partial-uploads --dry-run
+
+# remove all pending uploads regardless of age (e.g. after a failed batch)
+docker compose exec app python -m app.cli cleanup-partial-uploads --older-than-hours 0
+```
+
+Finalized files are never touched. In the UI, deleting a non-empty folder now
+prompts to cascade-delete its contents.
+
 **HDD note:** these Storage VPS plans are spinning disk. For low traffic that is
 fine; the only HDD-sensitive part is PostgreSQL under heavy concurrency, which a
 personal/low-traffic drive will not hit.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -376,9 +376,13 @@ export const createFolder = async (folderName: string, path?: string): Promise<C
   };
 };
 
-export const deleteFolder = async (path: string): Promise<ApiResult> => {
+export const deleteFolder = async (path: string, recursive = false): Promise<ApiResult> => {
   const folderId = await resolveFolderIdByPath(path);
-  const result = await DriveApiClient.authRequest<ApiResult>(`/v2/folders/${encodeURIComponent(folderId)}`, 'DELETE');
+  const query = recursive ? '?recursive=true' : '';
+  const result = await DriveApiClient.authRequest<ApiResult>(
+    `/v2/folders/${encodeURIComponent(folderId)}${query}`,
+    'DELETE'
+  );
   resetFolderPathCache();
   return result;
 };

--- a/frontend/src/hooks/useDriveActions.ts
+++ b/frontend/src/hooks/useDriveActions.ts
@@ -125,20 +125,51 @@ export function useDriveActions({
     }
     setLoading(true);
     setError('');
+
+    const removeFromState = (): void => {
+      setFolders((current) => current.filter((f) => f.folderId !== folder.folderId));
+      setSelectedItems((prev) => {
+        const next = new Set(prev);
+        next.delete(folder.folderId);
+        return next;
+      });
+    };
+
+    // The API rejects deleting a non-empty folder with 409 "Folder is not empty".
+    // Offer to cascade-delete its contents instead of dead-ending.
+    const handleFailure = async (message: string): Promise<void> => {
+      if (!/not empty/i.test(message)) {
+        setError(message);
+        return;
+      }
+      if (
+        !window.confirm(
+          `"${folder.name}" is not empty. Delete it and everything inside? This cannot be undone.`
+        )
+      ) {
+        return;
+      }
+      try {
+        const result = await deleteFolder(folder.path, true);
+        if (result.error) {
+          setError(result.error);
+        } else {
+          removeFromState();
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete folder');
+      }
+    };
+
     try {
       const result = await deleteFolder(folder.path);
-      if (!result.error) {
-        setFolders((current) => current.filter((f) => f.folderId !== folder.folderId));
-        setSelectedItems((prev) => {
-          const next = new Set(prev);
-          next.delete(folder.folderId);
-          return next;
-        });
+      if (result.error) {
+        await handleFailure(result.error);
       } else {
-        setError(result.error);
+        removeFromState();
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete folder');
+      await handleFailure(err instanceof Error ? err.message : 'Failed to delete folder');
     }
     setLoading(false);
   }


### PR DESCRIPTION
## Why

A failed/abandoned upload leaves a `pending` `File` row (and sometimes bytes on disk) because `finalize_upload` never runs. That debris clutters the drive and causes `409 "name already exists"` on retry — exactly what surfaced during setup.

## Backend — automatic + on-demand cleanup
- **Housekeeping sweep** now purges `pending` uploads older than `DRIVE_PARTIAL_UPLOAD_MAX_AGE_HOURS` (default **24h**, `0` disables), removing any leftover bytes. The grace period protects in-flight uploads.
- **New CLI**: `python -m app.cli cleanup-partial-uploads [--older-than-hours N] [--dry-run]` for immediate cleanup (use `--older-than-hours 0` to clear everything after a failed batch).
- Finalized (`ready`) files are never touched.

## Frontend — cascade folder delete
Deleting a **non-empty** folder previously dead-ended on `409 "Folder is not empty"`. It now asks *"…is not empty. Delete it and everything inside?"* and retries with `?recursive=true`.

## Tests / checks
- New tests: age + status filtering, leftover-byte removal, and the CLI (incl. `--dry-run`). Full suite **145 passed**, coverage **96.5%**.
- `ruff` and `mypy` clean; frontend `tsc --noEmit` clean.

## Usage on the server
```bash
docker compose exec app python -m app.cli cleanup-partial-uploads --dry-run
docker compose exec app python -m app.cli cleanup-partial-uploads --older-than-hours 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrRxK94EYsBtkKrsSZhfnQ)_