### PR TITLE
Add passkey (WebAuthn/FIDO2) authentication support

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,6 +32,14 @@ DRIVE_CORS_ALLOW_ORIGINS=*
 # DRIVE_LOGIN_WINDOW_SECONDS=300
 # DRIVE_LOGIN_LOCKOUT_SECONDS=900
 
+# Passkeys (WebAuthn). RP ID is the registrable domain (no scheme/port); origin
+# is the full scheme://host:port the frontend is served from (comma-separated to
+# allow several, e.g. the Vite dev server and the prod domain). localhost works
+# over plain HTTP for dev; production needs HTTPS and a real domain.
+# DRIVE_WEBAUTHN_RP_ID=localhost
+# DRIVE_WEBAUTHN_RP_NAME=Personal Drive
+# DRIVE_WEBAUTHN_ORIGIN=http://localhost:5173
+
 # Backups (a daily scheduler writes verified bundles to DRIVE_BACKUP_DIR).
 # DRIVE_BACKUP_DIR=./data/backups
 # DRIVE_BACKUP_INTERVAL_HOURS=24

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,15 @@ class Settings(BaseSettings):
     login_window_seconds: int = 300
     login_lockout_seconds: int = 900
 
+    # WebAuthn / passkeys. RP ID is the registrable domain (no scheme/port/path);
+    # origin is the full scheme://host:port the page is served from. localhost is a
+    # secure context, so http://localhost works for dev; production needs HTTPS and
+    # a real domain. ``webauthn_origin`` is a comma-split list so one config can
+    # cover the Vite dev server and the same-origin production build.
+    webauthn_rp_id: str = "localhost"
+    webauthn_rp_name: str = "Personal Drive"
+    webauthn_origin: Annotated[list[str], NoDecode] = ["http://localhost:5173"]
+
     # Per-user storage quota in bytes (0 = unlimited)
     user_quota_bytes: int = 0
 
@@ -69,7 +78,7 @@ class Settings(BaseSettings):
     serve_frontend: bool = True
     frontend_dir: Path = Path("./static")
 
-    @field_validator("cors_allow_origins", mode="before")
+    @field_validator("cors_allow_origins", "webauthn_origin", mode="before")
     @classmethod
     def _split_origins(cls, value: object) -> object:
         if isinstance(value, str):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,7 @@ from .routers import (
     public_download,
     public_links,
     shares,
+    webauthn,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
@@ -77,6 +78,7 @@ async def _validation_handler(_request: Request, exc: RequestValidationError) ->
 
 for router in (
     auth.router,
+    webauthn.router,
     files.router,
     folders.router,
     shares.router,

--- a/backend/app/migrations/versions/a1b2c3d4e5f6_webauthn_credentials.py
+++ b/backend/app/migrations/versions/a1b2c3d4e5f6_webauthn_credentials.py
@@ -1,0 +1,41 @@
+"""webauthn credentials
+
+Revision ID: a1b2c3d4e5f6
+Revises: b26729c3ee69
+Create Date: 2026-06-24 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'a1b2c3d4e5f6'
+down_revision = 'b26729c3ee69'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table('webauthn_credentials',
+    sa.Column('id', sa.String(length=64), nullable=False),
+    sa.Column('credential_id', sa.String(length=512), nullable=False),
+    sa.Column('public_key', sa.Text(), nullable=False),
+    sa.Column('sign_count', sa.BigInteger(), nullable=False),
+    sa.Column('transports', sa.JSON(), nullable=True),
+    sa.Column('user_id', sa.String(length=64), nullable=False),
+    sa.Column('name', sa.String(length=255), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('last_used_at', sa.DateTime(), nullable=True),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    with op.batch_alter_table('webauthn_credentials', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_webauthn_credentials_credential_id'), ['credential_id'], unique=True)
+        batch_op.create_index('ix_webauthn_user', ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('webauthn_credentials', schema=None) as batch_op:
+        batch_op.drop_index('ix_webauthn_user')
+        batch_op.drop_index(batch_op.f('ix_webauthn_credentials_credential_id'))
+
+    op.drop_table('webauthn_credentials')

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -49,6 +49,32 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
 
 
+class WebAuthnCredential(Base):
+    """A passkey (WebAuthn/FIDO2 credential) registered to a user.
+
+    A user may have many. ``credential_id`` and ``public_key`` are stored as
+    base64url strings (rather than raw bytes) so the schema is identical on
+    SQLite and Postgres; the router encodes/decodes at the boundary.
+    """
+
+    __tablename__ = "webauthn_credentials"
+    __table_args__ = (Index("ix_webauthn_user", "user_id"),)
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True, default=_uuid)
+    credential_id: Mapped[str] = mapped_column(
+        String(512), unique=True, index=True, nullable=False
+    )
+    public_key: Mapped[str] = mapped_column(Text, nullable=False)
+    sign_count: Mapped[int] = mapped_column(BigInteger, default=0, nullable=False)
+    transports: Mapped[list] = mapped_column(JSON, default=list)
+    user_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=_now)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
 class Folder(Base):
     __tablename__ = "folders"
     __table_args__ = (Index("ix_folders_owner_parent", "owner_id", "parent_folder_id"),)

--- a/backend/app/routers/webauthn.py
+++ b/backend/app/routers/webauthn.py
@@ -1,0 +1,213 @@
+"""Passkey (WebAuthn/FIDO2) registration and usernameless login.
+
+Two ceremonies, each split into an ``/options`` call (server issues a challenge)
+and a ``/verify`` call (server checks the authenticator's response). The
+challenge is carried between the two calls in a short-lived HMAC-signed token
+(``create_signed_token``) rather than server-side state, so no new storage is
+needed and the flow survives restarts and multiple workers.
+
+A successful login assertion ends by minting the *same* access token as the
+password login (``create_access_token``), so everything downstream of auth is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    options_to_json,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidRegistrationResponse,
+)
+from webauthn.helpers.structs import (
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+from ..config import settings
+from ..deps import CurrentUser, get_current_user, get_db
+from ..errors import ApiError
+from ..models import User, WebAuthnCredential
+from ..ratelimit import login_rate_limiter
+from ..schemas import PasskeyLoginVerifyRequest, PasskeyRegisterVerifyRequest
+from ..security import (
+    create_access_token,
+    create_signed_token,
+    verify_signed_token,
+)
+from ..utils import now_utc
+
+router = APIRouter(prefix="/v2/auth/passkey", tags=["auth"])
+
+# Challenge tokens are valid for five minutes — long enough for the user to
+# complete the OS/browser prompt, short enough to limit replay.
+_CHALLENGE_TTL = 300
+
+
+def _user_credentials(db: Session, user_id: str) -> list[WebAuthnCredential]:
+    stmt = select(WebAuthnCredential).where(WebAuthnCredential.user_id == user_id)
+    return list(db.execute(stmt).scalars().all())
+
+
+def _options_json(options) -> dict:
+    return json.loads(options_to_json(options))
+
+
+@router.post("/register/options")
+def register_options(
+    db: Session = Depends(get_db), user: CurrentUser = Depends(get_current_user)
+) -> dict:
+    existing = _user_credentials(db, user.id)
+    options = generate_registration_options(
+        rp_id=settings.webauthn_rp_id,
+        rp_name=settings.webauthn_rp_name,
+        user_id=user.id.encode("utf-8"),
+        user_name=user.email,
+        user_display_name=user.email,
+        exclude_credentials=[
+            PublicKeyCredentialDescriptor(id=base64url_to_bytes(c.credential_id))
+            for c in existing
+        ],
+        # Discoverable credential so the user can later sign in without typing
+        # their email (usernameless / one-tap login).
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.REQUIRED,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        ),
+    )
+    challenge_token = create_signed_token(
+        {"ch": bytes_to_base64url(options.challenge), "uid": user.id, "typ": "reg"},
+        expires_in=_CHALLENGE_TTL,
+    )
+    return {"options": _options_json(options), "challengeToken": challenge_token}
+
+
+@router.post("/register/verify", status_code=201)
+def register_verify(
+    payload: PasskeyRegisterVerifyRequest,
+    db: Session = Depends(get_db),
+    user: CurrentUser = Depends(get_current_user),
+) -> dict:
+    claims = verify_signed_token(payload.challengeToken)
+    if not claims or claims.get("typ") != "reg" or claims.get("uid") != user.id:
+        raise ApiError(400, "Invalid or expired challenge")
+
+    try:
+        verification = verify_registration_response(
+            credential=json.dumps(payload.credential),
+            expected_challenge=base64url_to_bytes(claims["ch"]),
+            expected_rp_id=settings.webauthn_rp_id,
+            expected_origin=settings.webauthn_origin,
+            require_user_verification=False,
+        )
+    except (InvalidRegistrationResponse, ValueError) as exc:
+        raise ApiError(400, f"Passkey registration failed: {exc}") from exc
+
+    credential_id = bytes_to_base64url(verification.credential_id)
+    already = db.execute(
+        select(WebAuthnCredential).where(
+            WebAuthnCredential.credential_id == credential_id
+        )
+    ).scalars().first()
+    if already is not None:
+        raise ApiError(409, "This passkey is already registered")
+
+    transports = payload.credential.get("response", {}).get("transports") or []
+    cred = WebAuthnCredential(
+        credential_id=credential_id,
+        public_key=bytes_to_base64url(verification.credential_public_key),
+        sign_count=verification.sign_count,
+        transports=transports,
+        user_id=user.id,
+        name=payload.name,
+    )
+    db.add(cred)
+    db.flush()
+    return {"registered": True, "credentialId": cred.id}
+
+
+@router.post("/login/options")
+def login_options(request: Request, db: Session = Depends(get_db)) -> dict:
+    client_ip = request.client.host if request.client else None
+    locked_for = login_rate_limiter.check_locked("passkey", client_ip)
+    if locked_for:
+        raise ApiError(429, f"Too many attempts. Try again in {locked_for} seconds.")
+
+    # Empty allow_credentials => the browser offers any discoverable credential
+    # for this RP (usernameless login).
+    options = generate_authentication_options(
+        rp_id=settings.webauthn_rp_id,
+        allow_credentials=[],
+        user_verification=UserVerificationRequirement.PREFERRED,
+    )
+    challenge_token = create_signed_token(
+        {"ch": bytes_to_base64url(options.challenge), "typ": "auth"},
+        expires_in=_CHALLENGE_TTL,
+    )
+    return {"options": _options_json(options), "challengeToken": challenge_token}
+
+
+@router.post("/login/verify")
+def login_verify(
+    payload: PasskeyLoginVerifyRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> dict:
+    client_ip = request.client.host if request.client else None
+    claims = verify_signed_token(payload.challengeToken)
+    if not claims or claims.get("typ") != "auth":
+        raise ApiError(400, "Invalid or expired challenge")
+
+    raw_id = payload.credential.get("id")
+    if not isinstance(raw_id, str):
+        raise ApiError(400, "Malformed passkey assertion")
+
+    cred = db.execute(
+        select(WebAuthnCredential).where(
+            WebAuthnCredential.credential_id == raw_id
+        )
+    ).scalars().first()
+    if cred is None:
+        login_rate_limiter.register_failure("passkey", client_ip)
+        raise ApiError(401, "Passkey not recognized")
+
+    try:
+        verification = verify_authentication_response(
+            credential=json.dumps(payload.credential),
+            expected_challenge=base64url_to_bytes(claims["ch"]),
+            expected_rp_id=settings.webauthn_rp_id,
+            expected_origin=settings.webauthn_origin,
+            credential_public_key=base64url_to_bytes(cred.public_key),
+            credential_current_sign_count=cred.sign_count,
+            require_user_verification=False,
+        )
+    except (InvalidAuthenticationResponse, ValueError) as exc:
+        login_rate_limiter.register_failure("passkey", client_ip)
+        raise ApiError(401, f"Passkey authentication failed: {exc}") from exc
+
+    user = db.get(User, cred.user_id)
+    if user is None:
+        raise ApiError(401, "Passkey authentication failed")
+
+    cred.sign_count = verification.new_sign_count
+    cred.last_used_at = now_utc()
+    db.flush()
+    login_rate_limiter.register_success("passkey", client_ip)
+    return {
+        "token": create_access_token(user.id, user.email),
+        "userId": user.id,
+        "email": user.email,
+    }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -24,6 +24,17 @@ class LoginRequest(BaseModel):
     password: str
 
 
+class PasskeyRegisterVerifyRequest(BaseModel):
+    credential: dict
+    challengeToken: str
+    name: str | None = Field(default=None, max_length=255)
+
+
+class PasskeyLoginVerifyRequest(BaseModel):
+    credential: dict
+    challengeToken: str
+
+
 class CreateUploadRequest(BaseModel):
     filename: str
     contentType: str | None = None

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -4,3 +4,6 @@ pytest==8.3.4
 pytest-cov==6.0.0
 ruff==0.8.4
 mypy==1.14.0
+# Software authenticator used by tests/test_webauthn.py to drive real WebAuthn
+# registration/assertion ceremonies.
+soft-webauthn==0.1.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ PyJWT==2.10.1
 psycopg2-binary==2.9.10
 alembic==1.14.0
 clamd==1.0.2
+webauthn==2.5.2

--- a/backend/tests/test_webauthn.py
+++ b/backend/tests/test_webauthn.py
@@ -1,0 +1,181 @@
+"""End-to-end passkey tests driven by a software authenticator.
+
+``soft_webauthn`` performs real attestation/assertion crypto, so these exercise
+the full ceremony through the four endpoints (not mocked verification). The two
+helpers below translate between the byte-shaped objects ``soft_webauthn`` speaks
+and the base64url JSON the browser (and our endpoints) exchange.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from conftest import auth_header, register_and_login
+from soft_webauthn import SoftWebauthnDevice
+
+from app.ratelimit import login_rate_limiter
+from app.security import create_signed_token
+
+ORIGIN = "http://localhost:5173"
+
+
+def _b64(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _options_to_device(options: dict) -> dict:
+    """Turn the endpoint's JSON options into the byte form soft_webauthn wants."""
+    pk = dict(options)
+    pk["challenge"] = _b64decode(pk["challenge"])
+    if "user" in pk:
+        pk = {**pk, "user": {**pk["user"], "id": _b64decode(pk["user"]["id"])}}
+    return {"publicKey": pk}
+
+
+def _attestation_to_json(att: dict) -> dict:
+    return {
+        "id": att["id"].rstrip(b"=").decode("ascii"),
+        "rawId": _b64(att["rawId"]),
+        "response": {
+            "clientDataJSON": _b64(att["response"]["clientDataJSON"]),
+            "attestationObject": _b64(att["response"]["attestationObject"]),
+            "transports": ["internal"],
+        },
+        "type": att["type"],
+        "clientExtensionResults": {},
+    }
+
+
+def _assertion_to_json(assn: dict) -> dict:
+    return {
+        "id": assn["id"].rstrip(b"=").decode("ascii"),
+        "rawId": _b64(assn["rawId"]),
+        "response": {
+            "authenticatorData": _b64(assn["response"]["authenticatorData"]),
+            "clientDataJSON": _b64(assn["response"]["clientDataJSON"]),
+            "signature": _b64(assn["response"]["signature"]),
+            "userHandle": _b64(assn["response"]["userHandle"]),
+        },
+        "type": assn["type"],
+        "clientExtensionResults": {},
+    }
+
+
+def _register_passkey(client, token, device: SoftWebauthnDevice, name: str | None = None):
+    opts = client.post("/v2/auth/passkey/register/options", headers=auth_header(token)).json()
+    att = device.create(_options_to_device(opts["options"]), ORIGIN)
+    return client.post(
+        "/v2/auth/passkey/register/verify",
+        json={
+            "credential": _attestation_to_json(att),
+            "challengeToken": opts["challengeToken"],
+            "name": name,
+        },
+        headers=auth_header(token),
+    )
+
+
+def _login_passkey(client, device: SoftWebauthnDevice):
+    opts = client.post("/v2/auth/passkey/login/options").json()
+    assn = device.get(_options_to_device(opts["options"]), ORIGIN)
+    return client.post(
+        "/v2/auth/passkey/login/verify",
+        json={"credential": _assertion_to_json(assn), "challengeToken": opts["challengeToken"]},
+    )
+
+
+def setup_function() -> None:
+    login_rate_limiter.reset()
+
+
+def test_register_options_requires_auth(client):
+    assert client.post("/v2/auth/passkey/register/options").status_code == 401
+
+
+def test_full_passkey_flow(client):
+    token, user_id, email = register_and_login(client)
+    device = SoftWebauthnDevice()
+
+    reg = _register_passkey(client, token, device, name="My Laptop")
+    assert reg.status_code == 201, reg.text
+    assert reg.json()["registered"] is True
+
+    login = _login_passkey(client, device)
+    assert login.status_code == 200, login.text
+    body = login.json()
+    assert body["userId"] == user_id
+    assert body["email"] == email
+
+    # The minted token is a real access token usable on protected endpoints.
+    resp = client.get("/v2/folders/root/children", headers=auth_header(body["token"]))
+    assert resp.status_code == 200
+
+
+def test_invalid_challenge_token_rejected(client):
+    token, _, _ = register_and_login(client)
+    device = SoftWebauthnDevice()
+    opts = client.post("/v2/auth/passkey/register/options", headers=auth_header(token)).json()
+    att = device.create(_options_to_device(opts["options"]), ORIGIN)
+    resp = client.post(
+        "/v2/auth/passkey/register/verify",
+        json={"credential": _attestation_to_json(att), "challengeToken": "not-a-real-token"},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 400
+
+
+def test_register_rejects_token_for_other_user(client):
+    token_a, _, _ = register_and_login(client)
+    _, user_b_id, _ = register_and_login(client)
+    device = SoftWebauthnDevice()
+    opts = client.post("/v2/auth/passkey/register/options", headers=auth_header(token_a)).json()
+    att = device.create(_options_to_device(opts["options"]), ORIGIN)
+    # A challenge token minted for a different user must not be accepted.
+    forged = create_signed_token(
+        {"ch": opts["options"]["challenge"], "uid": user_b_id, "typ": "reg"}, expires_in=300
+    )
+    resp = client.post(
+        "/v2/auth/passkey/register/verify",
+        json={"credential": _attestation_to_json(att), "challengeToken": forged},
+        headers=auth_header(token_a),
+    )
+    assert resp.status_code == 400
+
+
+def test_multiple_passkeys_per_user(client):
+    token, user_id, _ = register_and_login(client)
+    dev1, dev2 = SoftWebauthnDevice(), SoftWebauthnDevice()
+    assert _register_passkey(client, token, dev1).status_code == 201
+    assert _register_passkey(client, token, dev2).status_code == 201
+
+    assert _login_passkey(client, dev1).json()["userId"] == user_id
+    assert _login_passkey(client, dev2).json()["userId"] == user_id
+
+
+def test_unknown_credential_rejected(client):
+    register_and_login(client)
+    # A device that was never registered cannot log in.
+    stranger = SoftWebauthnDevice()
+    stranger.cred_init("localhost", b"ghost")
+    resp = _login_passkey(client, stranger)
+    assert resp.status_code == 401
+
+
+def test_replayed_assertion_rejected(client):
+    token, _, _ = register_and_login(client)
+    device = SoftWebauthnDevice()
+    _register_passkey(client, token, device)
+
+    opts = client.post("/v2/auth/passkey/login/options").json()
+    assn = device.get(_options_to_device(opts["options"]), ORIGIN)
+    payload = {"credential": _assertion_to_json(assn), "challengeToken": opts["challengeToken"]}
+
+    first = client.post("/v2/auth/passkey/login/verify", json=payload)
+    assert first.status_code == 200
+    # Replaying the same assertion fails the sign-count (clone) check.
+    replay = client.post("/v2/auth/passkey/login/verify", json=payload)
+    assert replay.status_code == 401

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.16.14",
         "@mui/material": "^5.16.14",
         "@mui/x-data-grid": "^6.20.4",
+        "@simplewebauthn/browser": "^13.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1563,6 +1564,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^5.16.14",
     "@mui/material": "^5.16.14",
     "@mui/x-data-grid": "^6.20.4",
+    "@simplewebauthn/browser": "^13.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,11 +32,12 @@ import GridViewRoundedIcon from '@mui/icons-material/GridViewRounded';
 import ViewListRoundedIcon from '@mui/icons-material/ViewListRounded';
 import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
+import KeyRoundedIcon from '@mui/icons-material/KeyRounded';
 import FolderSharedRoundedIcon from '@mui/icons-material/FolderSharedRounded';
 import FolderRoundedIcon from '@mui/icons-material/FolderRounded';
 import InsertDriveFileRoundedIcon from '@mui/icons-material/InsertDriveFileRounded';
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
-import { logout, getToken } from './auth';
+import { logout, getToken, registerPasskey, passkeySupported } from './auth';
 import { createFolder } from './api';
 import {
   fetchFiles,
@@ -311,6 +312,19 @@ function App(): JSX.Element {
     setFolderTreeByPath({});
     setExpandedFolders(new Set(['']));
     setCurrentPath('');
+  };
+
+  const handleAddPasskey = async (): Promise<void> => {
+    if (!token) return;
+    setError('');
+    try {
+      await registerPasskey(token);
+      setShareSuccess('Passkey added. You can now sign in with it.');
+    } catch (caughtError: unknown) {
+      const message =
+        caughtError instanceof Error ? caughtError.message : 'Could not add passkey';
+      setError(message);
+    }
   };
 
   // =========================================================================
@@ -794,15 +808,28 @@ function App(): JSX.Element {
             <Typography variant="h6" fontWeight={700}>
               Personal Drive
             </Typography>
-            <Button
-              color="inherit"
-              variant="outlined"
-              size="small"
-              onClick={handleLogout}
-              startIcon={<LogoutRoundedIcon />}
-            >
-              Logout
-            </Button>
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              {passkeySupported() && (
+                <Button
+                  color="inherit"
+                  variant="outlined"
+                  size="small"
+                  onClick={handleAddPasskey}
+                  startIcon={<KeyRoundedIcon />}
+                >
+                  Add passkey
+                </Button>
+              )}
+              <Button
+                color="inherit"
+                variant="outlined"
+                size="small"
+                onClick={handleLogout}
+                startIcon={<LogoutRoundedIcon />}
+              >
+                Logout
+              </Button>
+            </Box>
           </Toolbar>
         </Paper>
 

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -1,3 +1,4 @@
+import { startAuthentication, startRegistration } from '@simplewebauthn/browser';
 import { config } from './config';
 
 const TOKEN_KEY = 'drive.accessToken';
@@ -7,10 +8,17 @@ interface RegisterResult {
   confirmationRequired: boolean;
 }
 
-async function authRequest<T>(path: string, body: unknown): Promise<T> {
+interface PasskeyOptions {
+  options: Record<string, unknown>;
+  challengeToken: string;
+}
+
+async function authRequest<T>(path: string, body: unknown, token?: string): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
   const resp = await fetch(`${config.apiEndpoint}${path}`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(body)
   });
 
@@ -34,6 +42,44 @@ export const login = async (email: string, password: string): Promise<string> =>
   const result = await authRequest<{ token: string }>('/v2/auth/login', { email, password });
   localStorage.setItem(TOKEN_KEY, result.token);
   localStorage.setItem(EMAIL_KEY, email);
+  return result.token;
+};
+
+/** Returns true when the browser supports the WebAuthn APIs passkeys need. */
+export const passkeySupported = (): boolean =>
+  typeof window !== 'undefined' && !!window.PublicKeyCredential;
+
+/**
+ * Register a new passkey for the currently logged-in user. Requires the active
+ * access token because the credential is bound to the authenticated account.
+ */
+export const registerPasskey = async (token: string, name?: string): Promise<void> => {
+  const start = await authRequest<PasskeyOptions>(
+    '/v2/auth/passkey/register/options',
+    {},
+    token
+  );
+  const credential = await startRegistration({ optionsJSON: start.options as never });
+  await authRequest(
+    '/v2/auth/passkey/register/verify',
+    { credential, challengeToken: start.challengeToken, name },
+    token
+  );
+};
+
+/**
+ * Usernameless ("one-tap") passkey sign-in: the authenticator supplies the user
+ * handle, so no email is needed. Stores the returned token like password login.
+ */
+export const loginWithPasskey = async (): Promise<string> => {
+  const start = await authRequest<PasskeyOptions>('/v2/auth/passkey/login/options', {});
+  const credential = await startAuthentication({ optionsJSON: start.options as never });
+  const result = await authRequest<{ token: string; email: string }>(
+    '/v2/auth/passkey/login/verify',
+    { credential, challengeToken: start.challengeToken }
+  );
+  localStorage.setItem(TOKEN_KEY, result.token);
+  if (result.email) localStorage.setItem(EMAIL_KEY, result.email);
   return result.token;
 };
 

--- a/frontend/src/components/AuthForm.tsx
+++ b/frontend/src/components/AuthForm.tsx
@@ -9,7 +9,13 @@ import {
   TextField,
   Typography
 } from '@mui/material';
-import { login, register, confirmRegistration } from '../auth';
+import {
+  login,
+  register,
+  confirmRegistration,
+  loginWithPasskey,
+  passkeySupported
+} from '../auth';
 
 type AuthMode = 'login' | 'register' | 'confirm';
 
@@ -55,6 +61,18 @@ export function AuthForm({ onAuthenticated }: AuthFormProps): React.ReactElement
       }
     } catch (caughtError: unknown) {
       const message = caughtError instanceof Error ? caughtError.message : 'Registration failed';
+      setError(message);
+    }
+  };
+
+  const handlePasskeyLogin = async (): Promise<void> => {
+    setError('');
+    try {
+      const authToken = await loginWithPasskey();
+      onAuthenticated(authToken);
+    } catch (caughtError: unknown) {
+      const message =
+        caughtError instanceof Error ? caughtError.message : 'Passkey sign-in failed';
       setError(message);
     }
   };
@@ -133,6 +151,17 @@ export function AuthForm({ onAuthenticated }: AuthFormProps): React.ReactElement
                     ? 'Register'
                     : 'Confirm'}
               </Button>
+
+              {authMode === 'login' && passkeySupported() && (
+                <Button
+                  type="button"
+                  size="large"
+                  variant="outlined"
+                  onClick={handlePasskeyLogin}
+                >
+                  Sign in with a passkey
+                </Button>
+              )}
 
               {authMode === 'confirm' ? (
                 <Button variant="text" onClick={() => setAuthMode('login')}>


### PR DESCRIPTION
## Summary
This PR adds complete passkey (WebAuthn/FIDO2) support to the application, enabling users to register and authenticate using biometric or hardware security keys. The implementation includes usernameless ("one-tap") login where the authenticator supplies the user identity.

## Key Changes

**Backend**
- New `/v2/auth/passkey/*` router with four endpoints:
  - `POST /register/options` - Issues challenge for passkey registration (requires auth)
  - `POST /register/verify` - Verifies and stores new passkey credential
  - `POST /login/options` - Issues challenge for usernameless login
  - `POST /login/verify` - Verifies assertion and mints access token
- Added `WebAuthnCredential` model to store registered passkeys with credential ID, public key, sign count, and metadata
- Challenge tokens use HMAC-signed JWT (no server-side state) with 5-minute TTL
- Successful login returns standard access token, making downstream auth unchanged
- Rate limiting applied to login attempts
- Database migration to create `webauthn_credentials` table with proper indexes
- Configuration for WebAuthn RP ID, RP name, and allowed origins

**Frontend**
- New auth functions: `registerPasskey()`, `loginWithPasskey()`, `passkeySupported()`
- "Add passkey" button in app header (conditionally shown if browser supports WebAuthn)
- "Sign in with a passkey" button on login form
- Integration with `@simplewebauthn/browser` library for ceremony handling
- Proper error handling and user feedback for passkey operations

**Configuration**
- Added `webauthn_rp_id`, `webauthn_rp_name`, and `webauthn_origin` settings
- Environment variables documented in `.env.example`
- Supports comma-separated origins for dev/prod flexibility

## Notable Implementation Details

- Challenge transport uses signed tokens rather than server-side session state, enabling stateless operation across multiple workers
- Credential ID is base64url-encoded for database storage (schema-agnostic across SQLite/Postgres)
- Sign count validation prevents cloned authenticator attacks
- Transports metadata captured during registration for UX optimization
- Last-used timestamp tracked for credential management
- Full end-to-end test coverage using `soft_webauthn` software authenticator

https://claude.ai/code/session_011U1tNiPpeUHJNkpAcAj6gA