### PR TITLE
Make WebAuthn RP ID and origin auto-derive from request headers

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,13 +32,16 @@ DRIVE_CORS_ALLOW_ORIGINS=*
 # DRIVE_LOGIN_WINDOW_SECONDS=300
 # DRIVE_LOGIN_LOCKOUT_SECONDS=900
 
-# Passkeys (WebAuthn). RP ID is the registrable domain (no scheme/port); origin
-# is the full scheme://host:port the frontend is served from (comma-separated to
-# allow several, e.g. the Vite dev server and the prod domain). localhost works
-# over plain HTTP for dev; production needs HTTPS and a real domain.
-# DRIVE_WEBAUTHN_RP_ID=localhost
+# Passkeys (WebAuthn). By default the RP ID and origin are derived from each
+# request's Origin header, so passkeys work on whatever domain the app is served
+# from with no configuration. Set these only to pin them (e.g. frontend on a
+# different host than the API, or a proxy that rewrites Origin). RP ID is the
+# registrable domain (no scheme/port); origin is the full scheme://host:port,
+# comma-separated to allow several. Note: passkeys require a real domain or
+# localhost over a secure context — a bare IP address will not work.
+# DRIVE_WEBAUTHN_RP_ID=drive.example.com
 # DRIVE_WEBAUTHN_RP_NAME=Personal Drive
-# DRIVE_WEBAUTHN_ORIGIN=http://localhost:5173
+# DRIVE_WEBAUTHN_ORIGIN=https://drive.example.com
 
 # Backups (a daily scheduler writes verified bundles to DRIVE_BACKUP_DIR).
 # DRIVE_BACKUP_DIR=./data/backups

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,14 +33,16 @@ class Settings(BaseSettings):
     login_window_seconds: int = 300
     login_lockout_seconds: int = 900
 
-    # WebAuthn / passkeys. RP ID is the registrable domain (no scheme/port/path);
-    # origin is the full scheme://host:port the page is served from. localhost is a
-    # secure context, so http://localhost works for dev; production needs HTTPS and
-    # a real domain. ``webauthn_origin`` is a comma-split list so one config can
-    # cover the Vite dev server and the same-origin production build.
-    webauthn_rp_id: str = "localhost"
+    # WebAuthn / passkeys. By default the RP ID and origin are derived from each
+    # incoming request (the browser's Origin/Referer), so passkeys work on
+    # whatever domain the app is actually served from without configuration.
+    # Set these only to pin them explicitly — e.g. when the frontend lives on a
+    # different host than the API, or behind a proxy that rewrites Origin. RP ID
+    # is the registrable domain (no scheme/port/path); origin is the full
+    # scheme://host:port, comma-split so several can be allowed at once.
+    webauthn_rp_id: str = ""
     webauthn_rp_name: str = "Personal Drive"
-    webauthn_origin: Annotated[list[str], NoDecode] = ["http://localhost:5173"]
+    webauthn_origin: Annotated[list[str], NoDecode] = []
 
     # Per-user storage quota in bytes (0 = unlimited)
     user_quota_bytes: int = 0

--- a/backend/app/routers/webauthn.py
+++ b/backend/app/routers/webauthn.py
@@ -14,6 +14,7 @@ unchanged.
 from __future__ import annotations
 
 import json
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, Request
 from sqlalchemy import select
@@ -57,6 +58,30 @@ router = APIRouter(prefix="/v2/auth/passkey", tags=["auth"])
 _CHALLENGE_TTL = 300
 
 
+def _resolve_rp(request: Request) -> tuple[str, list[str]]:
+    """Determine the WebAuthn RP ID and acceptable origin(s) for this request.
+
+    Explicit config wins (for split-domain / proxy deployments). Otherwise both
+    are derived from the browser's ``Origin`` (falling back to ``Referer``)
+    header so passkeys work on whatever domain the app is served from without
+    any configuration. The final fallback keeps non-browser callers (tests)
+    working.
+    """
+    if settings.webauthn_rp_id:
+        origins = list(settings.webauthn_origin)
+        return settings.webauthn_rp_id, origins
+
+    for header in ("origin", "referer"):
+        value = request.headers.get(header)
+        if not value:
+            continue
+        parsed = urlparse(value)
+        if parsed.scheme and parsed.hostname:
+            return parsed.hostname, [f"{parsed.scheme}://{parsed.netloc}"]
+
+    return "localhost", ["http://localhost:5173"]
+
+
 def _user_credentials(db: Session, user_id: str) -> list[WebAuthnCredential]:
     stmt = select(WebAuthnCredential).where(WebAuthnCredential.user_id == user_id)
     return list(db.execute(stmt).scalars().all())
@@ -68,11 +93,14 @@ def _options_json(options) -> dict:
 
 @router.post("/register/options")
 def register_options(
-    db: Session = Depends(get_db), user: CurrentUser = Depends(get_current_user)
+    request: Request,
+    db: Session = Depends(get_db),
+    user: CurrentUser = Depends(get_current_user),
 ) -> dict:
+    rp_id, _ = _resolve_rp(request)
     existing = _user_credentials(db, user.id)
     options = generate_registration_options(
-        rp_id=settings.webauthn_rp_id,
+        rp_id=rp_id,
         rp_name=settings.webauthn_rp_name,
         user_id=user.id.encode("utf-8"),
         user_name=user.email,
@@ -98,6 +126,7 @@ def register_options(
 @router.post("/register/verify", status_code=201)
 def register_verify(
     payload: PasskeyRegisterVerifyRequest,
+    request: Request,
     db: Session = Depends(get_db),
     user: CurrentUser = Depends(get_current_user),
 ) -> dict:
@@ -105,12 +134,13 @@ def register_verify(
     if not claims or claims.get("typ") != "reg" or claims.get("uid") != user.id:
         raise ApiError(400, "Invalid or expired challenge")
 
+    rp_id, origins = _resolve_rp(request)
     try:
         verification = verify_registration_response(
             credential=json.dumps(payload.credential),
             expected_challenge=base64url_to_bytes(claims["ch"]),
-            expected_rp_id=settings.webauthn_rp_id,
-            expected_origin=settings.webauthn_origin,
+            expected_rp_id=rp_id,
+            expected_origin=origins,
             require_user_verification=False,
         )
     except (InvalidRegistrationResponse, ValueError) as exc:
@@ -146,10 +176,11 @@ def login_options(request: Request, db: Session = Depends(get_db)) -> dict:
     if locked_for:
         raise ApiError(429, f"Too many attempts. Try again in {locked_for} seconds.")
 
+    rp_id, _ = _resolve_rp(request)
     # Empty allow_credentials => the browser offers any discoverable credential
     # for this RP (usernameless login).
     options = generate_authentication_options(
-        rp_id=settings.webauthn_rp_id,
+        rp_id=rp_id,
         allow_credentials=[],
         user_verification=UserVerificationRequirement.PREFERRED,
     )
@@ -184,12 +215,13 @@ def login_verify(
         login_rate_limiter.register_failure("passkey", client_ip)
         raise ApiError(401, "Passkey not recognized")
 
+    rp_id, origins = _resolve_rp(request)
     try:
         verification = verify_authentication_response(
             credential=json.dumps(payload.credential),
             expected_challenge=base64url_to_bytes(claims["ch"]),
-            expected_rp_id=settings.webauthn_rp_id,
-            expected_origin=settings.webauthn_origin,
+            expected_rp_id=rp_id,
+            expected_origin=origins,
             credential_public_key=base64url_to_bytes(cred.public_key),
             credential_current_sign_count=cred.sign_count,
             require_user_verification=False,

--- a/backend/tests/test_webauthn.py
+++ b/backend/tests/test_webauthn.py
@@ -65,9 +65,13 @@ def _assertion_to_json(assn: dict) -> dict:
     }
 
 
-def _register_passkey(client, token, device: SoftWebauthnDevice, name: str | None = None):
-    opts = client.post("/v2/auth/passkey/register/options", headers=auth_header(token)).json()
-    att = device.create(_options_to_device(opts["options"]), ORIGIN)
+def _register_passkey(
+    client, token, device: SoftWebauthnDevice, name: str | None = None, origin: str = ORIGIN
+):
+    headers = auth_header(token)
+    req_headers = {**headers, "Origin": origin}
+    opts = client.post("/v2/auth/passkey/register/options", headers=req_headers).json()
+    att = device.create(_options_to_device(opts["options"]), origin)
     return client.post(
         "/v2/auth/passkey/register/verify",
         json={
@@ -75,16 +79,18 @@ def _register_passkey(client, token, device: SoftWebauthnDevice, name: str | Non
             "challengeToken": opts["challengeToken"],
             "name": name,
         },
-        headers=auth_header(token),
+        headers=req_headers,
     )
 
 
-def _login_passkey(client, device: SoftWebauthnDevice):
-    opts = client.post("/v2/auth/passkey/login/options").json()
-    assn = device.get(_options_to_device(opts["options"]), ORIGIN)
+def _login_passkey(client, device: SoftWebauthnDevice, origin: str = ORIGIN):
+    req_headers = {"Origin": origin}
+    opts = client.post("/v2/auth/passkey/login/options", headers=req_headers).json()
+    assn = device.get(_options_to_device(opts["options"]), origin)
     return client.post(
         "/v2/auth/passkey/login/verify",
         json={"credential": _assertion_to_json(assn), "challengeToken": opts["challengeToken"]},
+        headers=req_headers,
     )
 
 
@@ -113,6 +119,23 @@ def test_full_passkey_flow(client):
     # The minted token is a real access token usable on protected endpoints.
     resp = client.get("/v2/folders/root/children", headers=auth_header(body["token"]))
     assert resp.status_code == 200
+
+
+def test_passkey_works_on_custom_domain(client):
+    # No DRIVE_WEBAUTHN_* config is set, so the RP ID / origin must be derived
+    # from the request's Origin header — this is what makes passkeys work on
+    # whatever domain the app is actually served from.
+    token, user_id, _ = register_and_login(client)
+    device = SoftWebauthnDevice()
+    origin = "https://drive.example.com"
+
+    reg = _register_passkey(client, token, device, origin=origin)
+    assert reg.status_code == 201, reg.text
+    assert device.rp_id == "drive.example.com"
+
+    login = _login_passkey(client, device, origin=origin)
+    assert login.status_code == 200, login.text
+    assert login.json()["userId"] == user_id
 
 
 def test_invalid_challenge_token_rejected(client):


### PR DESCRIPTION
## Summary
This change makes WebAuthn (passkeys) configuration more flexible by automatically deriving the RP ID and origin from incoming request headers instead of requiring explicit configuration. This allows passkeys to work seamlessly on any domain the app is served from without additional setup.

## Key Changes
- **Added `_resolve_rp()` function** that determines the RP ID and acceptable origins by:
  - Using explicit config if set (for split-domain/proxy deployments)
  - Falling back to parsing the request's `Origin` header (or `Referer` as fallback)
  - Using `localhost` and `http://localhost:5173` as final fallback for non-browser callers (tests)

- **Updated WebAuthn endpoints** to use dynamic RP ID and origins:
  - `register/options`: Now calls `_resolve_rp()` to get the RP ID
  - `register/verify`: Uses resolved RP ID and origins for verification
  - `login/options`: Uses resolved RP ID
  - `login/verify`: Uses resolved RP ID and origins for verification

- **Changed default configuration**:
  - `webauthn_rp_id` defaults to empty string (was `"localhost"`)
  - `webauthn_origin` defaults to empty list (was `["http://localhost:5173"]`)
  - Updated documentation to reflect that these are now optional

- **Updated tests** to verify the new behavior:
  - Modified `_register_passkey()` and `_login_passkey()` helpers to accept custom `origin` parameter
  - Added `test_passkey_works_on_custom_domain()` to verify passkeys work on arbitrary domains without explicit config

## Implementation Details
- The `_resolve_rp()` function uses `urllib.parse.urlparse` to safely extract hostname and scheme from request headers
- The function prioritizes explicit config over request-derived values, maintaining backward compatibility
- Request header parsing is defensive: it only uses parsed values if both scheme and hostname are present
- The fallback to `localhost` ensures tests and non-browser clients continue to work

https://claude.ai/code/session_011U1tNiPpeUHJNkpAcAj6gA