### PR TITLE
Share Caddy across apps via the `web` network; route Hearth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
       - name: Compose up + health smoke
         run: |
           echo "DRIVE_SECRET_KEY=ci-secret" > .env
+          # The compose file references an external `web` network (shared proxy).
+          docker network create web 2>/dev/null || true
           docker compose up -d
           ok=""
           for i in $(seq 1 40); do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,10 @@ jobs:
           DRIVE_USER_QUOTA_BYTES: ${{ vars.DRIVE_USER_QUOTA_BYTES || '0' }}
           DRIVE_BACKUP_INTERVAL_HOURS: ${{ vars.DRIVE_BACKUP_INTERVAL_HOURS || '24' }}
           DRIVE_BACKUP_RETENTION: ${{ vars.DRIVE_BACKUP_RETENTION || '10' }}
+          # Co-hosted sibling app routed by this Caddy over the shared `web`
+          # network. Leave both unset to keep the Hearth site block inert.
+          HEARTH_SITE_ADDRESS: ${{ vars.HEARTH_SITE_ADDRESS || '' }}
+          HEARTH_UPSTREAM: ${{ vars.HEARTH_UPSTREAM || '' }}
         run: |
           set -euo pipefail
 
@@ -97,6 +101,8 @@ jobs:
             echo "DRIVE_USER_QUOTA_BYTES=${DRIVE_USER_QUOTA_BYTES}"
             echo "DRIVE_BACKUP_INTERVAL_HOURS=${DRIVE_BACKUP_INTERVAL_HOURS}"
             echo "DRIVE_BACKUP_RETENTION=${DRIVE_BACKUP_RETENTION}"
+            echo "HEARTH_SITE_ADDRESS=${HEARTH_SITE_ADDRESS}"
+            echo "HEARTH_UPSTREAM=${HEARTH_UPSTREAM}"
           } > drive.env
 
           # Ship the rendered env, then deploy.
@@ -115,6 +121,8 @@ jobs:
             # Sync to the exact state of origin/main and (re)build the stack.
             git fetch origin main
             git reset --hard origin/main
+            # Shared cross-app proxy network (idempotent; safe if it exists).
+            docker network create web 2>/dev/null || true
             docker compose --profile antivirus up -d --build
             docker image prune -f
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -11,3 +11,13 @@
 {$DRIVE_SITE_ADDRESS::80} {
 	reverse_proxy app:8000
 }
+
+# Co-hosted sibling app (Hearth), reached over the shared external `web` network.
+# Inert by default: HEARTH_SITE_ADDRESS defaults to an unused internal port
+# (:8081, plain HTTP, no cert attempted) so CI and a Hearth-less deploy are
+# unaffected. Set HEARTH_SITE_ADDRESS (its domain) and HEARTH_UPSTREAM
+# (its container:port on `web`) as repo Variables to start serving it over HTTPS.
+{$HEARTH_SITE_ADDRESS::8081} {
+	reverse_proxy {$HEARTH_UPSTREAM:127.0.0.1:9}
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,10 @@ services:
     environment:
       # ":80" = plain HTTP on the server IP. Set to a domain for auto-HTTPS.
       DRIVE_SITE_ADDRESS: ${DRIVE_SITE_ADDRESS:-:80}
+      # Co-hosted sibling app routed by Caddy over the shared `web` network.
+      # Defaults keep the block inert (no domain, no cert) until configured.
+      HEARTH_SITE_ADDRESS: ${HEARTH_SITE_ADDRESS:-:8081}
+      HEARTH_UPSTREAM: ${HEARTH_UPSTREAM:-127.0.0.1:9}
     ports:
       - "80:80"
       - "443:443"
@@ -78,6 +82,11 @@ services:
     dns:
       - 1.1.1.1
       - 8.8.8.8
+    # Join the shared `web` network so Caddy can reach co-hosted apps' containers
+    # by name, in addition to this project's default network (for `app`).
+    networks:
+      - default
+      - web
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
@@ -99,6 +108,14 @@ services:
       timeout: 10s
       retries: 5
       start_period: 120s
+
+networks:
+  # Project-local network (app, db, clamav).
+  default:
+  # Shared cross-app network for the reverse proxy to reach co-hosted apps.
+  # Create it once on the host/CI: `docker network create web`.
+  web:
+    external: true
 
 volumes:
   db_data:

--- a/docs/DEPLOYMENT_CONTABO.md
+++ b/docs/DEPLOYMENT_CONTABO.md
@@ -373,3 +373,33 @@ Find and disable it, then redeploy:
 sudo ss -tlnp 'sport = :80'
 sudo systemctl disable --now caddy   # or nginx / apache2
 ```
+
+## 12. Co-hosting another app behind this proxy
+
+This Caddy can front additional apps on the same VPS (two HTTPS domains can't each
+own ports 80/443, so they share one proxy). Caddy joins a shared external Docker
+network named `web` and routes each domain to the right container.
+
+One-time, on the host:
+
+```bash
+docker network create web        # idempotent; the deploy also ensures this
+```
+
+Then, for each co-hosted app:
+
+1. In the sibling app's `docker-compose.yml`, attach its app container to the
+   external `web` network and give it a stable name/alias (e.g. `hearth-app`).
+   It must **not** publish ports 80/443.
+2. Add two repository **Variables** here (Settings → Secrets and variables →
+   Actions → Variables) and re-run this app's Deploy once:
+
+   | Variable | Example |
+   |---|---|
+   | `HEARTH_SITE_ADDRESS` | `hearth.example.com` |
+   | `HEARTH_UPSTREAM` | `hearth-app:8000` |
+
+Caddy then serves the sibling domain over HTTPS (auto Let's Encrypt) and proxies
+to its container. Until both Variables are set they default to an inert internal
+listener, so CI and a Hearth-less deploy are unaffected. The sibling's domain
+needs its own DNS A record at the VPS.


### PR DESCRIPTION
Closing in favor of #41. We rebranded the sibling app from the placeholder "Hearth" to **space-io**, and #41 implements the concrete, hardcoded version (`personal-area.personal-drive-io.com` → `space-io:7777`). This branch is superseded and is being deleted.