### PR TITLE
Add single sign-on cookie support for co-hosted editor

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,6 +43,19 @@ DRIVE_CORS_ALLOW_ORIGINS=*
 # DRIVE_WEBAUTHN_RP_NAME=Personal Drive
 # DRIVE_WEBAUTHN_ORIGIN=https://drive.example.com
 
+# Single sign-on cookie (OPTIONAL — only needed to co-host the space-io editor).
+# The drive mirrors the access token into a cookie so a sibling app on a
+# subdomain is signed in by the same login. The drive works fine with these at
+# their defaults; the editor is an opt-in plug-in. To share the session across
+# subdomains, set the cookie domain to the registrable parent (note the leading
+# dot) and give the editor the SAME DRIVE_SECRET_KEY. Leave the domain empty for
+# a host-only cookie (the drive then runs fully standalone). Set
+# DRIVE_SSO_COOKIE_SECURE=false only for plain-HTTP local dev.
+# DRIVE_SSO_COOKIE_NAME=drive_sso
+# DRIVE_SSO_COOKIE_DOMAIN=.example.com
+# DRIVE_SSO_COOKIE_SECURE=true
+# DRIVE_SSO_COOKIE_SAMESITE=lax
+
 # Backups (a daily scheduler writes verified bundles to DRIVE_BACKUP_DIR).
 # DRIVE_BACKUP_DIR=./data/backups
 # DRIVE_BACKUP_INTERVAL_HOURS=24

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,6 +44,18 @@ class Settings(BaseSettings):
     webauthn_rp_name: str = "Personal Drive"
     webauthn_origin: Annotated[list[str], NoDecode] = []
 
+    # Single sign-on cookie. The access token is mirrored into a cookie so a
+    # sibling app on a co-hosted subdomain (the space-io editor at
+    # ``personal-area.<domain>``) is signed in by the same passkey login without
+    # a second prompt. Set ``sso_cookie_domain`` to the registrable parent
+    # domain (e.g. ``.example.com``) so the cookie is shared across subdomains;
+    # leave it empty for a host-only cookie (fine on localhost). The editor
+    # verifies the token with the *same* ``secret_key``.
+    sso_cookie_name: str = "drive_sso"
+    sso_cookie_domain: str = ""
+    sso_cookie_secure: bool = True
+    sso_cookie_samesite: str = "lax"
+
     # Per-user storage quota in bytes (0 = unlimited)
     user_quota_bytes: int = 0
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
@@ -54,7 +54,7 @@ class Settings(BaseSettings):
     sso_cookie_name: str = "drive_sso"
     sso_cookie_domain: str = ""
     sso_cookie_secure: bool = True
-    sso_cookie_samesite: str = "lax"
+    sso_cookie_samesite: Literal["lax", "strict", "none"] = "lax"
 
     # Per-user storage quota in bytes (0 = unlimited)
     user_quota_bytes: int = 0

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import secrets
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -15,6 +15,7 @@ from ..models import User
 from ..ratelimit import login_rate_limiter
 from ..schemas import ConfirmRequest, LoginRequest, RegisterRequest
 from ..security import create_access_token, hash_password, verify_password
+from ..sso import clear_sso_cookie, set_sso_cookie
 
 router = APIRouter(prefix="/v2/auth", tags=["auth"])
 
@@ -67,7 +68,12 @@ def confirm(payload: ConfirmRequest, db: Session = Depends(get_db)) -> dict:
 
 
 @router.post("/login")
-def login(payload: LoginRequest, request: Request, db: Session = Depends(get_db)) -> dict:
+def login(
+    payload: LoginRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict:
     client_ip = request.client.host if request.client else None
     locked_for = login_rate_limiter.check_locked(payload.email, client_ip)
     if locked_for:
@@ -81,8 +87,18 @@ def login(payload: LoginRequest, request: Request, db: Session = Depends(get_db)
         raise ApiError(403, "Account is not confirmed yet")
 
     login_rate_limiter.register_success(payload.email, client_ip)
+    token = create_access_token(user.id, user.email)
+    set_sso_cookie(response, token)
     return {
-        "token": create_access_token(user.id, user.email),
+        "token": token,
         "userId": user.id,
         "email": user.email,
     }
+
+
+@router.post("/logout")
+def logout(response: Response) -> dict:
+    """Clear the SSO cookie. The Bearer token in localStorage is dropped by the
+    frontend separately; this only revokes the cross-subdomain cookie."""
+    clear_sso_cookie(response)
+    return {"loggedOut": True}

--- a/backend/app/routers/webauthn.py
+++ b/backend/app/routers/webauthn.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 from urllib.parse import urlparse
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 from webauthn import (
@@ -49,6 +49,7 @@ from ..security import (
     create_signed_token,
     verify_signed_token,
 )
+from ..sso import set_sso_cookie
 from ..utils import now_utc
 
 router = APIRouter(prefix="/v2/auth/passkey", tags=["auth"])
@@ -195,6 +196,7 @@ def login_options(request: Request, db: Session = Depends(get_db)) -> dict:
 def login_verify(
     payload: PasskeyLoginVerifyRequest,
     request: Request,
+    response: Response,
     db: Session = Depends(get_db),
 ) -> dict:
     client_ip = request.client.host if request.client else None
@@ -238,8 +240,10 @@ def login_verify(
     cred.last_used_at = now_utc()
     db.flush()
     login_rate_limiter.register_success("passkey", client_ip)
+    token = create_access_token(user.id, user.email)
+    set_sso_cookie(response, token)
     return {
-        "token": create_access_token(user.id, user.email),
+        "token": token,
         "userId": user.id,
         "email": user.email,
     }

--- a/backend/app/sso.py
+++ b/backend/app/sso.py
@@ -1,0 +1,40 @@
+"""Single sign-on cookie helpers.
+
+The access token issued at login is also written to a cookie so a co-hosted
+sibling app (the space-io editor on ``personal-area.<domain>``) recognises the
+same session. The cookie carries the *same* JWT returned in the JSON body —
+the editor verifies it with the shared ``secret_key`` — so there is no second
+token format to maintain.
+
+The cookie is ``HttpOnly`` (JS never needs it; only the backends read it) and,
+when ``sso_cookie_domain`` is set to the registrable parent domain, is shared
+across every subdomain under it.
+"""
+
+from __future__ import annotations
+
+from fastapi import Response
+
+from .config import settings
+
+
+def set_sso_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=settings.sso_cookie_name,
+        value=token,
+        max_age=settings.access_token_expiry_minutes * 60,
+        domain=settings.sso_cookie_domain or None,
+        secure=settings.sso_cookie_secure,
+        httponly=True,
+        samesite=settings.sso_cookie_samesite,
+        path="/",
+    )
+
+
+def clear_sso_cookie(response: Response) -> None:
+    # Domain/path must match the original for the browser to actually drop it.
+    response.delete_cookie(
+        key=settings.sso_cookie_name,
+        domain=settings.sso_cookie_domain or None,
+        path="/",
+    )

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,8 @@
 # same-origin and this can be left empty. For `npm run dev` against a backend on
 # another port, point it at that backend:
 VITE_API_ENDPOINT=http://localhost:8000
+
+# Full URL of the co-hosted space-io editor ("My Space"). OPTIONAL — when set, a
+# "My Space" link appears in the top bar; leave empty to run the drive on its own
+# with no editor link (the editor is an opt-in plug-in).
+# VITE_PERSONAL_AREA_URL=https://personal-area.example.com

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,9 @@ import FolderSharedRoundedIcon from '@mui/icons-material/FolderSharedRounded';
 import FolderRoundedIcon from '@mui/icons-material/FolderRounded';
 import InsertDriveFileRoundedIcon from '@mui/icons-material/InsertDriveFileRounded';
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
+import AutoStoriesRoundedIcon from '@mui/icons-material/AutoStoriesRounded';
 import { logout, getToken, registerPasskey, passkeySupported } from './auth';
+import { config } from './config';
 import { createFolder } from './api';
 import {
   fetchFiles,
@@ -809,6 +811,18 @@ function App(): JSX.Element {
               Personal Drive
             </Typography>
             <Box sx={{ display: 'flex', gap: 1 }}>
+              {config.personalAreaUrl && (
+                <Button
+                  color="inherit"
+                  variant="outlined"
+                  size="small"
+                  href={config.personalAreaUrl}
+                  startIcon={<AutoStoriesRoundedIcon />}
+                  title="Open My Space — your notes editor"
+                >
+                  My Space
+                </Button>
+              )}
               {passkeySupported() && (
                 <Button
                   color="inherit"

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -86,6 +86,12 @@ export const loginWithPasskey = async (): Promise<string> => {
 export const logout = (): void => {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(EMAIL_KEY);
+  // Best-effort: also clear the shared SSO cookie so the co-hosted editor is
+  // signed out too. Fire-and-forget — local state is cleared regardless.
+  void fetch(`${config.apiEndpoint}/v2/auth/logout`, {
+    method: 'POST',
+    credentials: 'include'
+  }).catch(() => undefined);
 };
 
 export const getToken = async (): Promise<string | null> => localStorage.getItem(TOKEN_KEY);

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -4,8 +4,13 @@ interface AppConfig {
   // against a separate backend, set VITE_API_ENDPOINT (e.g.
   // http://localhost:8000).
   apiEndpoint: string;
+  // Full URL of the co-hosted space-io editor ("My Space"). When set, a link to
+  // it appears in the top bar; the shared SSO cookie keeps the user signed in
+  // across the jump. Empty hides the link (e.g. when the editor isn't deployed).
+  personalAreaUrl: string;
 }
 
 export const config: AppConfig = {
-  apiEndpoint: import.meta.env.VITE_API_ENDPOINT ?? ''
+  apiEndpoint: import.meta.env.VITE_API_ENDPOINT ?? '',
+  personalAreaUrl: import.meta.env.VITE_PERSONAL_AREA_URL ?? ''
 };


### PR DESCRIPTION
## Summary
This PR adds single sign-on (SSO) cookie support to enable seamless session sharing between the Personal Drive and a co-hosted space-io editor on a sibling subdomain. When a user logs in via email or passkey, the access token is mirrored into a shared cookie that the editor can verify using the same secret key, eliminating the need for a second login prompt.

## Key Changes

**Backend:**
- New `sso.py` module with `set_sso_cookie()` and `clear_sso_cookie()` helpers that manage HttpOnly cookies with configurable domain, security, and SameSite settings
- Updated `/v2/auth/login` endpoint to set the SSO cookie on successful email/password login
- Updated `/v2/auth/passkey/login_verify` endpoint to set the SSO cookie on successful passkey login
- New `/v2/auth/logout` endpoint to clear the SSO cookie when users sign out
- Added four new configuration options in `config.py`:
  - `sso_cookie_name`: Cookie identifier (default: `drive_sso`)
  - `sso_cookie_domain`: Registrable parent domain for cross-subdomain sharing (default: empty for host-only)
  - `sso_cookie_secure`: HTTPS enforcement (default: `true`)
  - `sso_cookie_samesite`: SameSite attribute (default: `lax`)
- Updated `.env.example` with SSO cookie configuration documentation

**Frontend:**
- Added `personalAreaUrl` config option to `config.ts` (sourced from `VITE_PERSONAL_AREA_URL` env var)
- Added "My Space" button in the top bar that links to the editor when `personalAreaUrl` is configured
- Updated `logout()` function to call the new `/v2/auth/logout` endpoint (fire-and-forget) to clear the SSO cookie
- Updated `.env.example` with the new editor URL configuration

## Implementation Details

- The SSO cookie carries the **same JWT token** returned in the login response, eliminating the need for a separate token format
- The cookie is `HttpOnly` to prevent JavaScript access (only backends read it)
- When `sso_cookie_domain` is set to the registrable parent domain (e.g., `.example.com`), the cookie is automatically shared across all subdomains
- The editor verifies the token using the shared `secret_key`, requiring no additional configuration beyond the domain setting
- Logout is best-effort on the frontend; local state is cleared regardless of whether the SSO cookie clear succeeds

https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14