### PR TITLE
feat(passkey): enable WebAuthn PRF on passkey registration (P2)

### DIFF
--- a/backend/app/routers/webauthn.py
+++ b/backend/app/routers/webauthn.py
@@ -121,7 +121,13 @@ def register_options(
         {"ch": bytes_to_base64url(options.challenge), "uid": user.id, "typ": "reg"},
         expires_in=_CHALLENGE_TTL,
     )
-    return {"options": _options_json(options), "challengeToken": challenge_token}
+    options_json = _options_json(options)
+    # Enable the WebAuthn PRF (hmac-secret) extension so this credential can later
+    # derive a stable per-credential secret. The drive never evaluates PRF itself;
+    # the co-hosted space-io editor uses the PRF output to derive its
+    # note-encryption key. A drive running on its own simply ignores it.
+    options_json.setdefault("extensions", {})["prf"] = {}
+    return {"options": options_json, "challengeToken": challenge_token}
 
 
 @router.post("/register/verify", status_code=201)


### PR DESCRIPTION
## What

Enable the WebAuthn **PRF (`hmac-secret`)** extension on passkey registration by injecting `extensions: { prf: {} }` into the registration options.

## Why

This is the drive-side half of **P2** of the editor↔drive integration. The co-hosted space-io editor derives its **note-encryption key** from the PRF output of this same email-less passkey, keeping notes end-to-end encrypted under one credential. The drive itself never evaluates PRF — it just creates the credential so it *supports* a stable per-credential secret later.

## Decoupling

The change references nothing about the editor and doesn't touch drive login or the user model. A drive deployed on its own simply ignores the extension — the editor remains an opt-in plug-in.

> **Note:** PRF must be present at credential creation, so existing passkeys need to be **re-registered once** to unlock the editor. New passkeys get it automatically.

## Implementation

- `app/routers/webauthn.py` — `register_options` now sets `options_json["extensions"]["prf"] = {}` on the returned options. SimpleWebAuthn forwards the extension verbatim, so no frontend change is needed.

## Testing

Verified locally:
- `ruff check app tests` ✅
- `mypy app` ✅
- `pytest tests/test_webauthn.py` — **8 passed** ✅ (`soft_webauthn` ignores the unknown extension; the register/login ceremonies are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14)_