### PR TITLE
feat(preview): in-app file previews — PDF/DOCX/image/video (P3)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
         "@mui/material": "^5.16.14",
         "@mui/x-data-grid": "^6.20.4",
         "@simplewebauthn/browser": "^13.3.0",
+        "mammoth": "^1.12.0",
+        "pdfjs-dist": "^5.7.284",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -1198,6 +1200,256 @@
         "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1685,6 +1937,24 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -1700,6 +1970,26 @@
         "npm": ">=6"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
@@ -1712,6 +2002,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.4",
@@ -1792,6 +2088,12 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -1840,6 +2142,12 @@
         }
       }
     },
+    "node_modules/dingbat-to-unicode": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dingbat-to-unicode/-/dingbat-to-unicode-1.0.1.tgz",
+      "integrity": "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -1848,6 +2156,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/duck": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/duck/-/duck-0.1.12.tgz",
+      "integrity": "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==",
+      "license": "BSD",
+      "dependencies": {
+        "underscore": "^1.13.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2024,6 +2341,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2039,6 +2362,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2060,6 +2389,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2098,6 +2433,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -2116,6 +2472,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lop": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
+      "integrity": "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "duck": "^0.1.12",
+        "option": "~0.2.1",
+        "underscore": "^1.13.1"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2124,6 +2491,30 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/mammoth": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz",
+      "integrity": "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.6",
+        "argparse": "~1.0.3",
+        "base64-js": "^1.5.1",
+        "bluebird": "~3.4.0",
+        "dingbat-to-unicode": "^1.0.1",
+        "jszip": "^3.7.1",
+        "lop": "^0.4.2",
+        "path-is-absolute": "^1.0.0",
+        "underscore": "^1.13.1",
+        "xmlbuilder": "^10.0.0"
+      },
+      "bin": {
+        "mammoth": "bin/mammoth"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ms": {
@@ -2170,6 +2561,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/option": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/option/-/option-0.2.4.tgz",
+      "integrity": "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2200,6 +2603,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2213,6 +2625,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.7.284",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
+      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.100"
       }
     },
     "node_modules/picocolors": {
@@ -2262,6 +2686,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -2335,6 +2765,21 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/reselect": {
@@ -2418,6 +2863,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2437,6 +2888,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2454,6 +2911,21 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/stylis": {
@@ -2505,6 +2977,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -2535,6 +3013,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.3",
@@ -2609,6 +3093,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,8 @@
     "@mui/material": "^5.16.14",
     "@mui/x-data-grid": "^6.20.4",
     "@simplewebauthn/browser": "^13.3.0",
+    "mammoth": "^1.12.0",
+    "pdfjs-dist": "^5.7.284",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,6 +69,7 @@ import { FileColumnsFactory, ListColumnsFactory } from './components/FileColumns
 import { GridLayout, type GridSize } from './components/GridLayout';
 import { ListLayout } from './components/ListLayout';
 import { ContextMenu } from './components/ContextMenu';
+import { PreviewModal } from './components/Preview/PreviewModal';
 import { RenameDialog } from './components/RenameDialog';
 import { MoveDialog } from './components/MoveDialog';
 import { ShareDialog } from './components/ShareDialog';
@@ -163,6 +164,9 @@ function App(): JSX.Element {
   // --- Share dialog state ---
   const [shareTarget, setShareTarget] = useState<ShareTarget>(null);
   const [shareSuccess, setShareSuccess] = useState('');
+
+  // --- Preview modal state ---
+  const [previewFile, setPreviewFile] = useState<DriveFile | null>(null);
 
   // --- Shared with me state ---
   const [driveTab, setDriveTab] = useState<DriveTab>('my-drive');
@@ -385,6 +389,12 @@ function App(): JSX.Element {
   const handleCtxClose = (): void => {
     setCtxTarget(null);
     setCtxPosition(null);
+  };
+
+  const handleCtxPreview = (): void => {
+    if (ctxTarget?.type === 'file') {
+      setPreviewFile(ctxTarget.file);
+    }
   };
 
   const handleCtxRename = (): void => {
@@ -1070,6 +1080,7 @@ function App(): JSX.Element {
                       onDeleteFolder={handleDeleteFolder}
                       onContextMenu={handleContextMenu}
                       onSelectionChange={handleGridSelectionChange}
+                      onFilePreview={setPreviewFile}
                       onDrop={handleDrop}
                       onExternalDropUpload={(folder, dataTransfer) => {
                         void uploadFromDataTransfer(dataTransfer, folder.path);
@@ -1084,6 +1095,7 @@ function App(): JSX.Element {
                       loading={loading}
                       selectedItems={selectedItems}
                       onFolderClick={(folder) => handleFolderSelection(folder.path)}
+                      onFileOpen={setPreviewFile}
                       onContextMenu={handleContextMenu}
                       onSelectionChange={handleListSelectionChange}
                     />
@@ -1219,6 +1231,7 @@ function App(): JSX.Element {
                 : 'Download'
             }
             onClose={handleCtxClose}
+            onPreview={handleCtxPreview}
             onRename={handleCtxRename}
             onMoveTo={handleCtxMoveTo}
             onDownload={handleCtxDownload}
@@ -1247,6 +1260,13 @@ function App(): JSX.Element {
             onClose={() => setShareTarget(null)}
             onSubmit={handleShareSubmit}
             onShareChanged={handleShareChanged}
+          />
+
+          <PreviewModal
+            file={previewFile}
+            onClose={() => setPreviewFile(null)}
+            getDownloadUrl={getFileDownloadUrl}
+            onDownload={handleDownload}
           />
 
           <Snackbar

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -11,7 +11,9 @@ import DriveFileMoveRoundedIcon from '@mui/icons-material/DriveFileMoveRounded';
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
 import ShareRoundedIcon from '@mui/icons-material/ShareRounded';
 import DeleteOutlineRoundedIcon from '@mui/icons-material/DeleteOutlineRounded';
+import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
 import type { ContextMenuTarget, ContextMenuPosition } from '../types/drive';
+import { previewKind } from '../service/fileUtils';
 
 export type { ContextMenuTarget, ContextMenuPosition } from '../types/drive';
 
@@ -25,6 +27,7 @@ export interface ContextMenuProps {
   /** Label for Download item: "Download" or "Download as ZIP (N items)". */
   downloadLabel?: string;
   onClose: () => void;
+  onPreview: () => void;
   onRename: () => void;
   onMoveTo: () => void;
   onDownload: () => void;
@@ -39,6 +42,7 @@ export function ContextMenu({
   showDownload = false,
   downloadLabel = 'Download',
   onClose,
+  onPreview,
   onRename,
   onMoveTo,
   onDownload,
@@ -48,6 +52,9 @@ export function ContextMenu({
   const open = target !== null && position !== null;
   const isBulk = selectedCount > 1;
   const isFile = target?.type === 'file';
+  // Only offer "Preview" for a single file the in-app viewer can actually open.
+  const isPreviewable =
+    !isBulk && target?.type === 'file' && previewKind(target.file.filename) !== null;
 
   return (
     <Menu
@@ -61,6 +68,19 @@ export function ContextMenu({
         }
       }}
     >
+      {isPreviewable && (
+        <MenuItem
+          onClick={() => {
+            onClose();
+            onPreview();
+          }}
+        >
+          <ListItemIcon>
+            <VisibilityRoundedIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Preview</ListItemText>
+        </MenuItem>
+      )}
       {!isBulk && (
         <MenuItem
           onClick={() => {

--- a/frontend/src/components/GridLayout.tsx
+++ b/frontend/src/components/GridLayout.tsx
@@ -46,6 +46,8 @@ export interface GridLayoutProps {
     target: { type: 'file'; file: DriveFile } | { type: 'folder'; folder: DriveFolder }
   ) => void;
   onSelectionChange?: (id: string, multi: boolean) => void;
+  /** Open a file's preview (double-click). */
+  onFilePreview?: (file: DriveFile) => void;
   onDrop?: (
     targetFolder: DriveFolder,
     dragData: { type: 'file' | 'folder'; id: string }
@@ -69,6 +71,7 @@ export function GridLayout({
   onDeleteFolder,
   onContextMenu,
   onSelectionChange,
+  onFilePreview,
   onDrop,
   onExternalDropUpload,
   getDownloadUrl,
@@ -318,6 +321,7 @@ export function GridLayout({
             />
           )}
           <CardActionArea
+            onDoubleClick={() => onFilePreview?.(file)}
             sx={{
               flex: 1,
               display: 'flex',

--- a/frontend/src/components/ListLayout.tsx
+++ b/frontend/src/components/ListLayout.tsx
@@ -13,6 +13,8 @@ export interface ListLayoutProps {
   selectedItems?: Set<string>;
   /** When set, clicking a folder row opens that folder (navigates). */
   onFolderClick?: (folder: DriveFolder) => void;
+  /** Open a file's preview (double-click a file row). */
+  onFileOpen?: (file: DriveFile) => void;
   onContextMenu?: (
     e: React.MouseEvent,
     target: { type: 'file'; file: DriveFile } | { type: 'folder'; folder: DriveFolder }
@@ -26,6 +28,7 @@ export function ListLayout({
   loading = false,
   selectedItems,
   onFolderClick,
+  onFileOpen,
   onContextMenu,
   onSelectionChange
 }: ListLayoutProps): React.ReactElement {
@@ -38,6 +41,22 @@ export function ListLayout({
       }
     },
     [onFolderClick]
+  );
+
+  const handleRowDoubleClick = React.useCallback(
+    (e: React.MouseEvent) => {
+      // DataGrid has no onRowDoubleClick, so resolve the row from the DOM the
+      // same way the context-menu handler does.
+      const target = e.target as HTMLElement;
+      const rowEl = target.closest('[data-id]');
+      const rowId = rowEl?.getAttribute('data-id');
+      if (!rowId) return;
+      const row = rows.find((r) => r.id === rowId);
+      if (row?.type === 'file') {
+        onFileOpen?.(row.file);
+      }
+    },
+    [rows, onFileOpen]
   );
 
   const handleRowContextMenu = React.useCallback(
@@ -68,7 +87,11 @@ export function ListLayout({
     : [];
 
   return (
-    <Box sx={{ width: '100%', height: '100%', minHeight: 280 }} onContextMenu={handleRowContextMenu}>
+    <Box
+      sx={{ width: '100%', height: '100%', minHeight: 280 }}
+      onContextMenu={handleRowContextMenu}
+      onDoubleClick={handleRowDoubleClick}
+    >
       <DataGrid
         rows={rows}
         columns={columns}

--- a/frontend/src/components/Preview/DocxRenderer.tsx
+++ b/frontend/src/components/Preview/DocxRenderer.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import mammoth from 'mammoth';
+import { sanitizeHtml } from './sanitizeHtml';
+
+interface Props {
+  data: ArrayBuffer;
+}
+
+/** Renders a .docx as sanitised HTML via mammoth. Ported from the space-io
+ *  editor (the HTML is run through sanitizeHtml before it reaches the DOM). */
+export default function DocxRenderer({ data }: Props): React.ReactElement {
+  const [html, setHtml] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const result = await mammoth.convertToHtml({ arrayBuffer: data.slice(0) });
+        if (!cancelled) setHtml(sanitizeHtml(result.value));
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'failed to render DOCX');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
+  if (error) {
+    return (
+      <Typography color="error" sx={{ textAlign: 'center', py: 4 }}>
+        {error}
+      </Typography>
+    );
+  }
+  if (html === null) {
+    return (
+      <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
+        Rendering…
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ py: 3, px: { xs: 1, sm: 2 } }}>
+      <Box
+        sx={{
+          maxWidth: 760,
+          mx: 'auto',
+          p: { xs: 2.5, sm: 5 },
+          bgcolor: 'background.paper',
+          boxShadow: '0 1px 6px rgba(0,0,0,0.12)',
+          fontFamily: 'Georgia, "Times New Roman", serif',
+          color: 'text.primary',
+          '& h1, & h2, & h3, & h4': { mt: 2, mb: 1, lineHeight: 1.3 },
+          '& p': { my: 1, lineHeight: 1.7 },
+          '& ul, & ol': { pl: 3, my: 1 },
+          '& li': { my: 0.5 },
+          '& table': { borderCollapse: 'collapse', my: 2, width: '100%' },
+          '& td, & th': { border: '1px solid', borderColor: 'divider', p: 1 },
+          '& img': { maxWidth: '100%', height: 'auto' },
+          '& a': { color: 'primary.main' }
+        }}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/Preview/PdfRenderer.tsx
+++ b/frontend/src/components/Preview/PdfRenderer.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import * as pdfjsLib from 'pdfjs-dist';
+import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+
+interface Props {
+  data: ArrayBuffer;
+}
+
+/** Renders every page of a PDF to a canvas. Ported from the space-io editor. */
+export default function PdfRenderer({ data }: Props): React.ReactElement {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [pageCount, setPageCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const container = containerRef.current;
+    if (!container) return;
+    container.innerHTML = '';
+
+    (async () => {
+      try {
+        const doc = await pdfjsLib.getDocument({ data: data.slice(0) }).promise;
+        if (cancelled) {
+          doc.destroy();
+          return;
+        }
+        setPageCount(doc.numPages);
+        const scale = Math.min(2, window.devicePixelRatio || 1) * 1.2;
+        for (let pageNumber = 1; pageNumber <= doc.numPages; pageNumber += 1) {
+          if (cancelled) break;
+          const page = await doc.getPage(pageNumber);
+          const viewport = page.getViewport({ scale });
+          const canvas = document.createElement('canvas');
+          canvas.width = viewport.width;
+          canvas.height = viewport.height;
+          canvas.style.maxWidth = '100%';
+          canvas.style.height = 'auto';
+          canvas.style.display = 'block';
+          canvas.style.margin = '0 auto 12px';
+          canvas.style.boxShadow = '0 1px 6px rgba(0,0,0,0.18)';
+          container.appendChild(canvas);
+          const context = canvas.getContext('2d');
+          if (!context) continue;
+          await page.render({ canvasContext: context, viewport, canvas }).promise;
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'failed to render PDF');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [data]);
+
+  return (
+    <Box sx={{ p: 2 }}>
+      {error && (
+        <Typography color="error" sx={{ textAlign: 'center', py: 2 }}>
+          {error}
+        </Typography>
+      )}
+      <Box ref={containerRef} />
+      {pageCount > 0 && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: 'block', textAlign: 'center', py: 1 }}
+        >
+          {pageCount} {pageCount === 1 ? 'page' : 'pages'}
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/Preview/PreviewModal.tsx
+++ b/frontend/src/components/Preview/PreviewModal.tsx
@@ -1,0 +1,179 @@
+import React, { lazy, Suspense, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  Typography
+} from '@mui/material';
+import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
+import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
+import type { DriveFile } from '../../types/drive';
+import { previewKind } from '../../service/fileUtils';
+
+// Heavy renderers (pdf.js, mammoth) are split out so they only load when a
+// PDF/DOCX is actually opened.
+const PdfRenderer = lazy(() => import('./PdfRenderer'));
+const DocxRenderer = lazy(() => import('./DocxRenderer'));
+
+type State =
+  | { status: 'loading' }
+  | { status: 'url'; url: string }
+  | { status: 'bytes'; data: ArrayBuffer }
+  | { status: 'error'; message: string }
+  | { status: 'unsupported' };
+
+export interface PreviewModalProps {
+  /** The file to preview; null keeps the dialog closed. */
+  file: DriveFile | null;
+  onClose: () => void;
+  getDownloadUrl: (fileId: string) => Promise<string | undefined | null>;
+  onDownload: (file: DriveFile) => void;
+}
+
+export function PreviewModal({
+  file,
+  onClose,
+  getDownloadUrl,
+  onDownload
+}: PreviewModalProps): React.ReactElement {
+  const [state, setState] = useState<State>({ status: 'loading' });
+  const kind = file ? previewKind(file.filename) : null;
+
+  useEffect(() => {
+    if (!file) return;
+    const k = previewKind(file.filename);
+    if (k == null) {
+      setState({ status: 'unsupported' });
+      return;
+    }
+    let cancelled = false;
+    setState({ status: 'loading' });
+    (async () => {
+      try {
+        const url = await getDownloadUrl(file.fileId);
+        if (cancelled) return;
+        if (!url) {
+          setState({ status: 'error', message: 'Could not get a download link for this file.' });
+          return;
+        }
+        // Images and video stream straight from the signed URL.
+        if (k === 'image' || k === 'video') {
+          setState({ status: 'url', url });
+          return;
+        }
+        // PDF/DOCX need the bytes in memory for the renderer.
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`Download failed (${res.status})`);
+        const data = await res.arrayBuffer();
+        if (!cancelled) setState({ status: 'bytes', data });
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            status: 'error',
+            message: err instanceof Error ? err.message : 'Could not load the file.'
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [file, getDownloadUrl]);
+
+  const downloadFallback = file ? (
+    <Button
+      variant="outlined"
+      startIcon={<DownloadRoundedIcon />}
+      onClick={() => onDownload(file)}
+    >
+      Download
+    </Button>
+  ) : null;
+
+  return (
+    <Dialog
+      open={file !== null}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      PaperProps={{ sx: { height: '85vh', borderRadius: 2 } }}
+    >
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 1.25 }}>
+        <Typography
+          variant="subtitle1"
+          fontWeight={600}
+          noWrap
+          title={file?.filename}
+          sx={{ flex: 1, minWidth: 0 }}
+        >
+          {file?.filename}
+        </Typography>
+        {file && (
+          <Button size="small" startIcon={<DownloadRoundedIcon />} onClick={() => onDownload(file)}>
+            Download
+          </Button>
+        )}
+        <IconButton onClick={onClose} size="small" aria-label="Close preview">
+          <CloseRoundedIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0, bgcolor: 'grey.100', overflow: 'auto' }}>
+        {state.status === 'loading' && (
+          <Stack alignItems="center" justifyContent="center" sx={{ height: '100%', py: 6 }}>
+            <CircularProgress />
+          </Stack>
+        )}
+        {state.status === 'error' && (
+          <Stack alignItems="center" justifyContent="center" spacing={1.5} sx={{ height: '100%', py: 6 }}>
+            <Typography color="error">{state.message}</Typography>
+            {downloadFallback}
+          </Stack>
+        )}
+        {state.status === 'unsupported' && (
+          <Stack alignItems="center" justifyContent="center" spacing={1.5} sx={{ height: '100%', py: 6 }}>
+            <Typography color="text.secondary">No in-app preview for this file type.</Typography>
+            {downloadFallback}
+          </Stack>
+        )}
+        {state.status === 'url' && kind === 'image' && (
+          <Stack alignItems="center" justifyContent="center" sx={{ minHeight: '100%', p: 2 }}>
+            <Box
+              component="img"
+              src={state.url}
+              alt={file?.filename}
+              sx={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            />
+          </Stack>
+        )}
+        {state.status === 'url' && kind === 'video' && (
+          <Stack alignItems="center" justifyContent="center" sx={{ minHeight: '100%', p: 2 }}>
+            <Box
+              component="video"
+              src={state.url}
+              controls
+              preload="metadata"
+              sx={{ maxWidth: '100%', maxHeight: '100%' }}
+            />
+          </Stack>
+        )}
+        {state.status === 'bytes' && (
+          <Suspense
+            fallback={
+              <Stack alignItems="center" justifyContent="center" sx={{ height: '100%', py: 6 }}>
+                <CircularProgress />
+              </Stack>
+            }
+          >
+            {kind === 'pdf' && <PdfRenderer data={state.data} />}
+            {kind === 'docx' && <DocxRenderer data={state.data} />}
+          </Suspense>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/Preview/sanitizeHtml.ts
+++ b/frontend/src/components/Preview/sanitizeHtml.ts
@@ -1,0 +1,102 @@
+/**
+ * SVG/MathML foreign-content roots and template/noscript are classic
+ * mutation-XSS levers (a safe-looking tree re-parses into something
+ * executable); mammoth never emits them, so forbid them outright. Form
+ * controls carry submission behaviour and aren't document content; `input` is
+ * handled separately so GFM task-list checkboxes survive.
+ *
+ * Ported from the space-io editor so the drive can render DOCX previews on its
+ * own, with no runtime dependency on the editor.
+ */
+const FORBIDDEN_TAGS = new Set([
+  'script',
+  'iframe',
+  'object',
+  'embed',
+  'link',
+  'meta',
+  'style',
+  'base',
+  'frame',
+  'frameset',
+  'svg',
+  'math',
+  'template',
+  'noscript',
+  'form',
+  'button',
+  'textarea',
+  'select',
+  'option',
+]);
+
+const URL_ATTRS = new Set(['href', 'src', 'xlink:href', 'action', 'formaction']);
+
+/**
+ * The inert GFM task-list checkbox is the only `<input>` allowed through, pared
+ * down to these attributes so nothing like `onfocus=` or `formaction=` rides in.
+ */
+const CHECKBOX_KEEP_ATTRS = new Set(['type', 'checked', 'disabled']);
+
+function isAllowedCheckbox(el: Element): boolean {
+  return el.tagName.toLowerCase() === 'input' && el.getAttribute('type') === 'checkbox';
+}
+
+/**
+ * Reject control chars before the scheme check: some browsers fold
+ * `java\tscript:` back into a live scheme.
+ */
+function isSafeUrl(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (trimmed === '') { return true; }
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) { return false; }
+  if (/^\s*(javascript|data|vbscript|file)\s*:/i.test(trimmed)) { return false; }
+  return true;
+}
+
+/**
+ * Second-line HTML sanitiser for the only HTML we render from untrusted input:
+ * mammoth's DOCX-to-HTML conversion. Strips dangerous elements and `on*`
+ * handlers and downgrades unsafe URL schemes to `#`. Not a DOMPurify
+ * replacement for adversarial settings.
+ */
+export function sanitizeHtml(html: string): string {
+  if (!html) { return ''; }
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  walk(doc.body);
+  return doc.body.innerHTML;
+}
+
+function walk(node: Element): void {
+  const children = Array.from(node.children);
+  for (const child of children) {
+    const tag = child.tagName.toLowerCase();
+    if (FORBIDDEN_TAGS.has(tag)) {
+      child.remove();
+      continue;
+    }
+    if (tag === 'input') {
+      if (!isAllowedCheckbox(child)) {
+        child.remove();
+        continue;
+      }
+      for (const attr of Array.from(child.attributes)) {
+        if (!CHECKBOX_KEEP_ATTRS.has(attr.name.toLowerCase())) {
+          child.removeAttribute(attr.name);
+        }
+      }
+      continue;
+    }
+    for (const attr of Array.from(child.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (name.startsWith('on')) {
+        child.removeAttribute(attr.name);
+        continue;
+      }
+      if (URL_ATTRS.has(name) && !isSafeUrl(attr.value)) {
+        child.setAttribute(attr.name, '#');
+      }
+    }
+    walk(child);
+  }
+}

--- a/frontend/src/service/fileUtils.ts
+++ b/frontend/src/service/fileUtils.ts
@@ -6,6 +6,12 @@ export const IMAGE_EXTENSIONS = new Set([
   'jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg', 'avif'
 ]);
 
+// Only browser-playable containers belong here — others fall back to download
+// rather than rendering an empty <video>.
+export const VIDEO_EXTENSIONS = new Set([
+  'mp4', 'webm', 'ogg', 'ogv', 'mov', 'm4v'
+]);
+
 export function getExtension(filename: string): string | undefined {
   return filename.split('.').pop()?.toLowerCase();
 }
@@ -13,4 +19,23 @@ export function getExtension(filename: string): string | undefined {
 export function isImageFilename(filename: string): boolean {
   const ext = getExtension(filename);
   return ext != null && IMAGE_EXTENSIONS.has(ext);
+}
+
+export function isVideoFilename(filename: string): boolean {
+  const ext = getExtension(filename);
+  return ext != null && VIDEO_EXTENSIONS.has(ext);
+}
+
+/** Which in-app preview renderer handles this filename, or null to fall back to
+ *  download. Mirrors the space-io editor's supported set. */
+export type PreviewKind = 'image' | 'video' | 'pdf' | 'docx';
+
+export function previewKind(filename: string): PreviewKind | null {
+  const ext = getExtension(filename);
+  if (ext == null) return null;
+  if (IMAGE_EXTENSIONS.has(ext)) return 'image';
+  if (VIDEO_EXTENSIONS.has(ext)) return 'video';
+  if (ext === 'pdf') return 'pdf';
+  if (ext === 'docx') return 'docx';
+  return null;
 }


### PR DESCRIPTION
## What

**P3** of the editor↔drive integration: preview files **in-app** instead of downloading them. Double-click a file (or right-click → **Preview**) to open it in a modal.

Supported: **PDF** (pdf.js), **Word .docx** (mammoth), and **images / video** (native `<img>`/`<video>`). Anything else falls back to a Download button.

## How

- **`service/fileUtils.ts`** — `previewKind(filename)` detects image/video/pdf/docx by extension (the drive's `DriveFile` has no content-type).
- **`components/Preview/`** (new) — `PreviewModal` (MUI `Dialog`) + `PdfRenderer` + `DocxRenderer` + `sanitizeHtml`. The heavy pdf.js / mammoth renderers are `lazy()`-loaded into their own chunks, so they only download when a PDF/DOCX is actually opened.
- **Bytes** come from the existing signed download URL (`getFileDownloadUrl`) — no auth header needed to fetch. Images/video stream straight from the URL; PDF/DOCX are fetched as an `ArrayBuffer`.
- **Triggers** — `ContextMenu` gains a "Preview" item (only for previewable files); double-click opens in both grid (`GridLayout`) and list (`ListLayout`) views.

## Decoupling

The renderers are **copied in** (ported from the space-io editor, including its `sanitizeHtml`), so the drive previews files entirely on its own — **no runtime dependency on the editor**, and it stays independently deployable. The DOCX HTML is sanitised before it ever hits the DOM.

## Testing

- `tsc --noEmit && vite build` ✅ (renderers code-split into separate chunks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14)_