### PR TITLE
build: plumb integration env vars through Docker + compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Root .env for `docker compose` — copy to .env. These feed the compose file's
+# ${VAR} substitutions (build args + the app/db/caddy service environments).
+# The backend has many more tunables with sane defaults; see backend/.env.example
+# for the full list. Only DRIVE_SECRET_KEY is strictly required.
+
+# --- Core ---
+# JWT + signed-URL secret. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(48))"
+DRIVE_SECRET_KEY=change-me
+# PostgreSQL password for the bundled db service.
+DRIVE_PG_PASSWORD=change-me
+# Public address Caddy serves. ":80" = plain HTTP on the IP; a domain enables
+# automatic Let's Encrypt HTTPS.
+DRIVE_SITE_ADDRESS=:80
+
+# --- space-io editor plug-in (all optional; unset = standalone drive) ---
+# Editor URL → adds the "My Space" link. Baked into the frontend at build time,
+# so changing it requires a rebuild (`docker compose up -d --build`).
+# VITE_PERSONAL_AREA_URL=https://personal-area.example.com
+# Share the session cookie across subdomains (leading dot = parent domain).
+# DRIVE_SSO_COOKIE_DOMAIN=.example.com
+# DRIVE_SSO_COOKIE_NAME=drive_sso
+# DRIVE_SSO_COOKIE_SECURE=true
+# DRIVE_SSO_COOKIE_SAMESITE=lax
+# Pin the passkey RP to the shared parent domain (== editor VITE_WEBAUTHN_RP_ID),
+# and allow both app origins.
+# DRIVE_WEBAUTHN_RP_ID=example.com
+# DRIVE_WEBAUTHN_ORIGIN=https://example.com,https://personal-area.example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,12 @@ WORKDIR /frontend
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci --no-audit --no-fund
 COPY frontend/ ./
-RUN npm run build
+# Build-time UI config, baked into the bundle (frontend/.env is dockerignored,
+# so it's passed as a build arg from docker-compose instead). Optional: empty
+# hides the "My Space" link (standalone drive); in plug-in mode set it to the
+# space-io editor's URL, e.g. https://personal-area.example.com.
+ARG VITE_PERSONAL_AREA_URL=""
+RUN VITE_PERSONAL_AREA_URL="$VITE_PERSONAL_AREA_URL" npm run build
 
 # ---- Stage 2: runtime ----
 FROM python:3.11-slim-bookworm AS runtime

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,12 @@ services:
       retries: 5
 
   app:
-    build: .
+    build:
+      context: .
+      args:
+        # Baked into the frontend bundle at build time (see Dockerfile). Empty
+        # hides the "My Space" link; set it to pair with the space-io editor.
+        VITE_PERSONAL_AREA_URL: ${VITE_PERSONAL_AREA_URL:-}
     restart: unless-stopped
     depends_on:
       db:
@@ -36,6 +41,17 @@ services:
       DRIVE_SECRET_KEY: ${DRIVE_SECRET_KEY:?Set DRIVE_SECRET_KEY in a .env file}
       DRIVE_STORAGE_DIR: /data/blobs
       DRIVE_BACKUP_DIR: /data/backups
+      # --- space-io editor plug-in (all optional; unset = standalone drive). ---
+      # Share the session JWT across subdomains so the editor is signed in too;
+      # set the domain to the registrable parent with a leading dot.
+      DRIVE_SSO_COOKIE_DOMAIN: ${DRIVE_SSO_COOKIE_DOMAIN:-}
+      DRIVE_SSO_COOKIE_NAME: ${DRIVE_SSO_COOKIE_NAME:-drive_sso}
+      DRIVE_SSO_COOKIE_SECURE: ${DRIVE_SSO_COOKIE_SECURE:-true}
+      DRIVE_SSO_COOKIE_SAMESITE: ${DRIVE_SSO_COOKIE_SAMESITE:-lax}
+      # Pin the passkey RP to the shared parent domain (== editor's
+      # VITE_WEBAUTHN_RP_ID) and allow both app origins.
+      DRIVE_WEBAUTHN_RP_ID: ${DRIVE_WEBAUTHN_RP_ID:-}
+      DRIVE_WEBAUTHN_ORIGIN: ${DRIVE_WEBAUTHN_ORIGIN:-}
       # Trust Caddy's X-Forwarded-Proto/Host so the app builds https:// signed
       # blob URLs (request.base_url). Without this, uploads/downloads use http://
       # and the browser blocks them as mixed content on an HTTPS page. Safe to


### PR DESCRIPTION
## What

Makes the editor-pairing variables actually settable on a real `docker compose` deploy. (Before this, `VITE_PERSONAL_AREA_URL` had nowhere to go: `frontend/.env` is in `.dockerignore`, and the Dockerfile didn't accept a build arg — so the "My Space" link could never be baked into the image.)

- **Dockerfile** — frontend stage accepts `ARG VITE_PERSONAL_AREA_URL` and passes it to `npm run build`.
- **docker-compose.yml** — `app.build.args` forwards `${VITE_PERSONAL_AREA_URL}`, and the `app.environment` gains the SSO/WebAuthn runtime vars (`DRIVE_SSO_COOKIE_*`, `DRIVE_WEBAUTHN_RP_ID`/`ORIGIN`).
- **.env.example** (new, repo root) — the compose-level vars, with the integration ones documented.

All optional — with none set, the drive builds and runs exactly as before. Verified Vite bakes a `VITE_*` value from the build env into the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14)_