### PR TITLE
ci(deploy): render the editor-plug-in env into the server .env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,14 @@ jobs:
           DRIVE_USER_QUOTA_BYTES: ${{ vars.DRIVE_USER_QUOTA_BYTES || '0' }}
           DRIVE_BACKUP_INTERVAL_HOURS: ${{ vars.DRIVE_BACKUP_INTERVAL_HOURS || '24' }}
           DRIVE_BACKUP_RETENTION: ${{ vars.DRIVE_BACKUP_RETENTION || '10' }}
+          # --- space-io editor plug-in (defaults wire it to the production
+          #     domain; override via repository Variables, or blank them out for a
+          #     standalone drive). VITE_PERSONAL_AREA_URL is baked into the bundle
+          #     at build time via compose build.args. ---
+          VITE_PERSONAL_AREA_URL: ${{ vars.VITE_PERSONAL_AREA_URL || 'https://personal-area.personal-drive-io.com' }}
+          DRIVE_SSO_COOKIE_DOMAIN: ${{ vars.DRIVE_SSO_COOKIE_DOMAIN || '.personal-drive-io.com' }}
+          DRIVE_WEBAUTHN_RP_ID: ${{ vars.DRIVE_WEBAUTHN_RP_ID || 'personal-drive-io.com' }}
+          DRIVE_WEBAUTHN_ORIGIN: ${{ vars.DRIVE_WEBAUTHN_ORIGIN || 'https://personal-drive-io.com,https://www.personal-drive-io.com,https://personal-area.personal-drive-io.com' }}
         run: |
           set -euo pipefail
 
@@ -97,6 +105,10 @@ jobs:
             echo "DRIVE_USER_QUOTA_BYTES=${DRIVE_USER_QUOTA_BYTES}"
             echo "DRIVE_BACKUP_INTERVAL_HOURS=${DRIVE_BACKUP_INTERVAL_HOURS}"
             echo "DRIVE_BACKUP_RETENTION=${DRIVE_BACKUP_RETENTION}"
+            echo "VITE_PERSONAL_AREA_URL=${VITE_PERSONAL_AREA_URL}"
+            echo "DRIVE_SSO_COOKIE_DOMAIN=${DRIVE_SSO_COOKIE_DOMAIN}"
+            echo "DRIVE_WEBAUTHN_RP_ID=${DRIVE_WEBAUTHN_RP_ID}"
+            echo "DRIVE_WEBAUTHN_ORIGIN=${DRIVE_WEBAUTHN_ORIGIN}"
           } > drive.env
 
           # Ship the rendered env, then deploy.


### PR DESCRIPTION
## Why

The deploy workflow rendered only the core drive config, so the editor-pairing variables never reached the container.

## What

`deploy.yml` now also writes into the server `.env`:
- `VITE_PERSONAL_AREA_URL` — the "My Space" link, baked into the bundle at build time via `build.args`.
- `DRIVE_SSO_COOKIE_DOMAIN` — shares the session cookie across subdomains.
- `DRIVE_WEBAUTHN_RP_ID` + `DRIVE_WEBAUTHN_ORIGIN` — pins the passkey RP to the parent domain and allows the apex/www/personal-area origins.

All four **default to the production domain** (`personal-drive-io.com`) and are overridable via repo Variables; blank them out for a standalone drive.

## What you need to set

**Nothing new on the drive side** — the defaults cover it. (`DRIVE_SECRET_KEY` / `DRIVE_PG_PASSWORD`, already set, are unchanged.)

> Note: pinning the WebAuthn RP id means existing passkeys should be **re-registered once** — which you need anyway for the PRF extension that derives the editor's note key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvSVbHiyGN8BtU97oVYC14)_