### PR TITLE
feat(agent): send the drive structure up front, fetch file contents on demand

### DIFF
--- a/backend/app/agent/extract.py
+++ b/backend/app/agent/extract.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import io
 
-# Cap on how much extracted text we hand the model for one file.
-MAX_TEXT_OUTPUT = 24_000
+# Cap on how much extracted text we hand the model for one file. A preview is
+# plenty to classify a file; keeping it modest bounds context per read_file.
+MAX_TEXT_OUTPUT = 12_000
 # Never read more than this many bytes off disk for extraction.
 MAX_READ_BYTES = 5 * 1024 * 1024
 

--- a/backend/app/agent/loop.py
+++ b/backend/app/agent/loop.py
@@ -33,7 +33,10 @@ def run_turn(
     *,
     max_steps: int,
 ) -> dict[str, Any]:
-    messages = _with_system_prompt(incoming)
+    # Send the current drive structure up front so the model starts with the
+    # full map and only has to choose which files to read.
+    structure = tools.render_drive_tree(db, owner_id)
+    messages = _with_system_prompt(incoming, structure)
     catalogue = tools.tool_definitions()
 
     assistant_text: str | None = None
@@ -99,8 +102,8 @@ def _tool_result(call: dict[str, Any], content: str) -> dict[str, Any]:
     }
 
 
-def _with_system_prompt(incoming: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    out: list[dict[str, Any]] = [{"role": "system", "content": _system_prompt(_today_utc())}]
+def _with_system_prompt(incoming: list[dict[str, Any]], structure: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = [{"role": "system", "content": _system_prompt(_today_utc(), structure)}]
     # Drop any client-supplied system messages so the browser can't override the
     # server-owned instructions.
     out.extend(message for message in incoming if message.get("role") != "system")
@@ -111,25 +114,30 @@ def _today_utc() -> str:
     return f"{datetime.now(UTC):%A, %d %B %Y}"
 
 
-def _system_prompt(today: str) -> str:
+def _system_prompt(today: str, structure: str) -> str:
     return (
         "You are the file-organisation assistant built into a personal cloud drive. You help the user "
         "tidy and reorganise their files and folders.\n\n"
         "The drive is a tree of folders and files. Paths are relative to the drive root and use '/'. The "
-        "root is '/'. Every file and folder has a stable id shown by list_tree; always reference existing "
-        "items by their id.\n\n"
+        "root is '/'. Every file and folder has a stable id; always reference existing items by their id.\n\n"
         f"Today's date is {today} (UTC). Resolve relative references like \"today\" or \"this year\" against "
         "it; never infer the current date from a file's name or contents.\n\n"
-        "Read-only tools you may use freely: list_tree, read_file, search_files. Call list_tree first to see "
-        "what exists. Use read_file to understand a file's contents when that helps you group it.\n\n"
+        "The current drive structure is provided at the end of this message — review it first. It lists every "
+        "folder and file with its id, but NOT file contents. Decide from it which files you actually need to "
+        "open, then read only those with read_file (use it only when a file's name and type aren't enough to "
+        "place it). You don't need to call list_tree for the overview; use it only to expand a folder the "
+        "structure marked as truncated, and search_files to locate files by name. Pull in just what the task "
+        "needs.\n\n"
         "Tools that change the drive — create_folder, move_node, rename_node — are PROPOSED to the user and "
         "applied only after they approve. Emit all the steps of a reorganization as tool calls in a single "
         "turn so the user can review and approve the whole plan at once. Never claim a change is finished; "
         "after you propose, the system tells you whether it was applied or declined.\n\n"
         "Guidelines:\n"
-        "- Look at the real tree (and file contents when useful) before proposing moves.\n"
+        "- Base your plan on the structure below; read a file's contents only when you must to classify it.\n"
         "- To put files into a new folder, propose create_folder first, then move_node with that folder's "
         "path as the destination.\n"
         "- Use relative paths only — never absolute filesystem paths or '..'.\n"
-        "- Deleting files is not available; never promise to delete anything."
+        "- Deleting files is not available; never promise to delete anything.\n\n"
+        "Current drive structure (folders and files, each with its id — not file contents):\n"
+        f"{structure}"
     )

--- a/backend/app/agent/tools.py
+++ b/backend/app/agent/tools.py
@@ -26,6 +26,10 @@ from .extract import MAX_READ_BYTES, extract_text
 MAX_TREE_NODES = 2000
 MAX_TREE_CHARS = 40_000
 SEARCH_LIMIT = 50
+# list_tree shows a shallow overview by default and lets the model drill into a
+# specific folder, so a big drive is never dumped into the context at once.
+DEFAULT_TREE_DEPTH = 2
+MAX_TREE_DEPTH = 10
 
 # Tools that change the drive. The loop refuses to execute these and routes them
 # to the user for approval instead.
@@ -54,9 +58,24 @@ def tool_definitions() -> list[dict[str, Any]]:
     return [
         fn(
             "list_tree",
-            "List the whole drive as a tree of folders and files with their ids, paths, types, and sizes. "
-            "Call this first to see what exists before proposing any change.",
-            {"type": "object", "properties": {}, "additionalProperties": False},
+            "List folders and files as a tree, with their ids, types, and sizes. By default it shows the drive "
+            "root a couple of levels deep; folders that aren't expanded show an item count and how to expand "
+            "them. Pass `path` to drill into one folder and `depth` for how many levels to show — fetch only "
+            "what you need rather than listing the whole drive at once.",
+            {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": 'Folder to list, e.g. "/Documents". Defaults to the root "/".',
+                    },
+                    "depth": {
+                        "type": "integer",
+                        "description": "How many levels deep to show (1-10). Defaults to 2.",
+                    },
+                },
+                "additionalProperties": False,
+            },
         ),
         fn(
             "read_file",
@@ -124,7 +143,14 @@ def tool_definitions() -> list[dict[str, Any]]:
 
 def execute_readonly(db: Session, owner_id: str, name: str, args: dict[str, Any]) -> str:
     if name == "list_tree":
-        return _list_tree(db, owner_id)
+        path = args.get("path")
+        start_path = path if isinstance(path, str) and path.strip() else "/"
+        raw_depth = args.get("depth")
+        if isinstance(raw_depth, bool) or not isinstance(raw_depth, int | float):
+            depth = DEFAULT_TREE_DEPTH
+        else:
+            depth = max(1, min(MAX_TREE_DEPTH, int(raw_depth)))
+        return _list_tree(db, owner_id, start_path, depth)
     if name == "read_file":
         return _read_file(db, owner_id, args)
     if name == "search_files":
@@ -132,7 +158,17 @@ def execute_readonly(db: Session, owner_id: str, name: str, args: dict[str, Any]
     raise ApiError(400, f"unknown read-only tool: {name}")
 
 
-def _list_tree(db: Session, owner_id: str) -> str:
+def render_drive_tree(db: Session, owner_id: str) -> str:
+    """The full drive structure (folders + file names + ids, no contents), capped.
+    Fed to the model up front so it can pick which files it actually needs to read."""
+    return _list_tree(db, owner_id, "/", MAX_TREE_DEPTH)
+
+
+def _list_tree(db: Session, owner_id: str, start_path: str = "/", max_depth: int = DEFAULT_TREE_DEPTH) -> str:
+    start_id = _resolve_existing_folder_id(db, owner_id, start_path)
+    if start_id is None:
+        return f'Folder not found: "{start_path}". Call list_tree with no arguments to see the drive root.'
+
     folders = db.execute(select(Folder).where(Folder.owner_id == owner_id)).scalars().all()
     files = db.execute(select(File).where(File.owner_id == owner_id)).scalars().all()
 
@@ -159,26 +195,60 @@ def _list_tree(db: Session, owner_id: str) -> str:
         count += 1
         chars += len(line)
 
-    def walk(folder_id: str, path: str) -> None:
+    def walk(folder_id: str, path: str, depth: int) -> None:
         for folder in sorted(child_folders[folder_id], key=lambda f: f.name.lower()):
             if truncated:
                 return
             child_path = f"{path}/{folder.name}"
-            emit(f"{child_path}/  [folder id={folder.id}]")
-            walk(folder.id, child_path)
+            items = len(child_folders[folder.id]) + len(child_files[folder.id])
+            # At the depth frontier, summarise a non-empty folder instead of
+            # expanding it — the model can drill in with a targeted list_tree.
+            if depth >= max_depth and items > 0:
+                emit(f'{child_path}/  [folder id={folder.id}, {items} items — list_tree path="{child_path}" to expand]')
+            else:
+                emit(f"{child_path}/  [folder id={folder.id}]")
+                walk(folder.id, child_path, depth + 1)
         for file in sorted(child_files[folder_id], key=lambda f: f.filename.lower()):
             if truncated:
                 return
             emit(f"{path}/{file.filename}  [file id={file.id} type={file.content_type} size={file.size}]")
 
-    walk(ROOT_FOLDER_ID, "")
+    base = "" if start_id == ROOT_FOLDER_ID else "/" + "/".join(_path_segments(start_path))
+    walk(start_id, base, 1)
 
     if not lines:
-        return "(the drive is empty)"
+        return "(the drive is empty)" if start_id == ROOT_FOLDER_ID else f'(folder "{start_path}" is empty)'
     out = "\n".join(lines)
     if truncated:
-        out += "\n…(tree truncated; ask about a specific folder)"
+        out += '\n…(tree truncated; narrow with list_tree path="/Folder" or a smaller depth)'
     return out
+
+
+def _path_segments(path: str | None) -> list[str]:
+    if not path:
+        return []
+    return [seg for seg in path.replace("\\", "/").split("/") if seg and seg != "."]
+
+
+def _resolve_existing_folder_id(db: Session, owner_id: str, path: str | None) -> str | None:
+    """Resolve a '/'-relative path to an owned folder id (ROOT for '/'); None if
+    any segment doesn't exist."""
+    segments = _path_segments(path)
+    if any(seg == ".." for seg in segments):
+        return None
+    current = ROOT_FOLDER_ID
+    for seg in segments:
+        folder = db.execute(
+            select(Folder).where(
+                Folder.owner_id == owner_id,
+                Folder.parent_folder_id == current,
+                func.lower(Folder.name) == seg.lower(),
+            )
+        ).scalars().first()
+        if folder is None:
+            return None
+        current = folder.id
+    return current
 
 
 def _read_file(db: Session, owner_id: str, args: dict[str, Any]) -> str:

--- a/backend/tests/test_agent_loop.py
+++ b/backend/tests/test_agent_loop.py
@@ -1,8 +1,10 @@
 """The tool-calling loop: read-only inline, mutating as proposals, error paths."""
 
+import json
+
 import httpx
 import pytest
-from conftest import register_and_login
+from conftest import register_and_login, upload_file
 
 from app.agent.client import OpenRouterClient
 from app.agent.config import AgentConfig
@@ -95,6 +97,27 @@ def test_invalid_mutating_args_fed_back_to_model(client):
     assert turn["pending_actions"] == []
     tool_msgs = [m for m in turn["messages"] if m.get("role") == "tool"]
     assert tool_msgs and "error" in tool_msgs[0]["content"].lower()
+
+
+def test_drive_structure_is_sent_to_the_model_up_front(client):
+    token, user_id, _ = register_and_login(client)
+    upload_file(client, token, "taxes-2026.pdf")
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json=_assistant(content="ok"))
+
+    cfg = AgentConfig(api_key="sk-test", model="m", base_url="https://x/api/v1", max_steps=8)
+    chat = OpenRouterClient(cfg, http=httpx.Client(transport=httpx.MockTransport(handler)))
+    with SessionLocal() as db:
+        run_turn(chat, db, user_id, [_user("organize my files")], max_steps=8)
+
+    system = captured["body"]["messages"][0]
+    assert system["role"] == "system"
+    assert "Current drive structure" in system["content"]
+    assert "taxes-2026.pdf" in system["content"]  # the file map is sent without being asked
 
 
 def test_client_system_message_is_stripped(client):

--- a/backend/tests/test_agent_tools.py
+++ b/backend/tests/test_agent_tools.py
@@ -87,6 +87,54 @@ def test_unknown_readonly_tool_is_bad_request(client):
         tools.execute_readonly(db, user_id, "frobnicate", {})
 
 
+def test_list_tree_default_depth_summarizes_deep_folders(client):
+    token, user_id, _ = register_and_login(client)
+    a = _folder(client, token, "A")
+    b = _folder(client, token, "B", parent=a)
+    _folder(client, token, "C", parent=b)  # /A/B/C — below the default depth of 2
+    with SessionLocal() as db:
+        out = tools.execute_readonly(db, user_id, "list_tree", {})
+    assert "/A/" in out
+    assert 'list_tree path="/A/B" to expand' in out  # frontier folder summarised
+    assert "/A/B/C" not in out  # not pulled into context
+
+
+def test_list_tree_path_scopes_to_subtree(client):
+    token, user_id, _ = register_and_login(client)
+    a = _folder(client, token, "A")
+    _folder(client, token, "Sub", parent=a)
+    _folder(client, token, "Other")  # at root — must not appear when scoped to /A
+    with SessionLocal() as db:
+        out = tools.execute_readonly(db, user_id, "list_tree", {"path": "/A"})
+    assert "/A/Sub/" in out
+    assert "/Other" not in out
+
+
+def test_list_tree_depth_expands_more(client):
+    token, user_id, _ = register_and_login(client)
+    a = _folder(client, token, "A")
+    b = _folder(client, token, "B", parent=a)
+    _folder(client, token, "C", parent=b)
+    with SessionLocal() as db:
+        out = tools.execute_readonly(db, user_id, "list_tree", {"depth": 5})
+    assert "/A/B/C/" in out
+
+
+def test_list_tree_path_not_found(client):
+    _, user_id, _ = register_and_login(client)
+    with SessionLocal() as db:
+        out = tools.execute_readonly(db, user_id, "list_tree", {"path": "/nope"})
+    assert "Folder not found" in out
+
+
+def test_list_tree_empty_subfolder(client):
+    token, user_id, _ = register_and_login(client)
+    _folder(client, token, "Empty")
+    with SessionLocal() as db:
+        out = tools.execute_readonly(db, user_id, "list_tree", {"path": "/Empty"})
+    assert "is empty" in out
+
+
 # --- read_file --------------------------------------------------------------
 
 def test_read_file_returns_text(client):


### PR DESCRIPTION
## Why

The assistant's `list_tree` dumped the **entire drive** (up to 2000 nodes / 40KB) on every call, and every tool result persists in the conversation as it grows — so a large drive could overload the model's context. This makes the agent pull in only what a task needs.

## What

- **Structure sent first.** Every turn now begins with the full drive structure — folders + file names + ids, but **not** file contents — injected into the system prompt. The model starts with the whole map and only has to decide which files it actually needs to *read*, instead of fetching blindly.
- **`list_tree` is scoped and bounded.** New optional `path` (drill into one folder) and `depth` (default 2) arguments; folders past the depth frontier are summarised with an item count and how to expand them. The whole tree is no longer dumped on each call.
- **`read_file` returns a smaller preview** — enough to classify a file, not the whole thing.
- **Prompt updated** to plan from the provided structure and read contents only when a name/type isn't enough.

Net effect: cheap structure (names/ids) up front; expensive file contents fetched on demand, only for the files the model selects.

## Tests

New tests cover `path` scoping, depth limiting, drill-down hints, the empty/ not-found cases, and that the structure is sent to the model without being asked. `ruff` + `mypy` clean; backend suite green at **96%** coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116am7j6ue3HGG2E55rTrEx

---
_Generated by [Claude Code](https://claude.ai/code/session_0116am7j6ue3HGG2E55rTrEx)_