### PR TITLE
Refactor error handling and response schemas for consistency

### DIFF
--- a/backend/app/agent/apply.py
+++ b/backend/app/agent/apply.py
@@ -12,17 +12,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from ..errors import ApiError
-from ..models import Folder
 from ..services import (
     ROOT_FOLDER_ID,
     create_folder_core,
     move_or_rename_file_core,
     move_or_rename_folder_core,
 )
+from .pathutil import find_child_folder, path_segments
 
 if TYPE_CHECKING:
     from ..schemas import AgentOperation
@@ -78,18 +77,12 @@ def _apply_one(db: Session, owner_id: str, op: AgentOperation, created_paths: di
     raise ApiError(400, f"Unknown operation: {op.tool}")
 
 
-def _segments(path: str | None) -> list[str]:
-    if not path:
-        return []
-    return [seg for seg in path.replace("\\", "/").split("/") if seg and seg != "."]
-
-
 def _join(parent_path: str | None, name: str) -> str:
-    return "/" + "/".join([*_segments(parent_path), name])
+    return "/" + "/".join([*path_segments(parent_path), name])
 
 
 def _resolve_folder_path(db: Session, owner_id: str, path: str | None, created_paths: dict[str, str]) -> str:
-    segments = _segments(path)
+    segments = path_segments(path)
     if any(seg == ".." for seg in segments):
         raise ApiError(400, "Invalid path (must be relative to the drive root, no '..')")
     if not segments:
@@ -104,13 +97,7 @@ def _resolve_folder_path(db: Session, owner_id: str, path: str | None, created_p
         if acc in created_paths:
             current = created_paths[acc]
             continue
-        folder = db.execute(
-            select(Folder).where(
-                Folder.owner_id == owner_id,
-                Folder.parent_folder_id == current,
-                func.lower(Folder.name) == seg.lower(),
-            )
-        ).scalars().first()
+        folder = find_child_folder(db, owner_id, current, seg)
         if folder is None:
             raise ApiError(404, f"Destination folder not found: {path}")
         current = folder.id

--- a/backend/app/agent/config.py
+++ b/backend/app/agent/config.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ..config import settings
-
-DEFAULT_MODEL = "qwen/qwen3.6-27b"
-DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+from ..config import DEFAULT_AGENT_MODEL, DEFAULT_OPENROUTER_BASE_URL, settings
 
 
 @dataclass(frozen=True)
@@ -32,8 +29,8 @@ class AgentConfig:
     def from_settings(cls) -> AgentConfig:
         return cls(
             api_key=settings.openrouter_api_key.strip(),
-            model=(settings.agent_model or DEFAULT_MODEL).strip(),
-            base_url=(settings.openrouter_base_url or DEFAULT_BASE_URL).strip().rstrip("/"),
+            model=(settings.agent_model or DEFAULT_AGENT_MODEL).strip(),
+            base_url=(settings.openrouter_base_url or DEFAULT_OPENROUTER_BASE_URL).strip().rstrip("/"),
             # Clamp to a sane range so a typo can't run an unbounded tool loop.
             max_steps=max(1, min(24, settings.agent_max_steps)),
         )

--- a/backend/app/agent/pathutil.py
+++ b/backend/app/agent/pathutil.py
@@ -1,0 +1,28 @@
+"""Drive-path helpers shared by the agent's read-only tools and the apply
+endpoint, so both sides split and resolve '/'-relative paths identically."""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ..models import Folder
+
+
+def path_segments(path: str | None) -> list[str]:
+    """Split a '/'-relative drive path into clean segments (empty and ``.``
+    segments dropped; backslashes normalised)."""
+    if not path:
+        return []
+    return [seg for seg in path.replace("\\", "/").split("/") if seg and seg != "."]
+
+
+def find_child_folder(db: Session, owner_id: str, parent_id: str, name: str) -> Folder | None:
+    """Case-insensitive lookup of an owned child folder by name."""
+    return db.execute(
+        select(Folder).where(
+            Folder.owner_id == owner_id,
+            Folder.parent_folder_id == parent_id,
+            func.lower(Folder.name) == name.lower(),
+        )
+    ).scalars().first()

--- a/backend/app/agent/tools.py
+++ b/backend/app/agent/tools.py
@@ -143,6 +143,14 @@ def tool_definitions() -> list[dict[str, Any]]:
 # --- Read-only execution ----------------------------------------------------
 
 def execute_readonly(db: Session, owner_id: str, name: str, args: dict[str, Any]) -> str:
+    """Run one read-only tool call and return the model-facing result text.
+
+    Error contract: malformed calls (unknown tool, missing/invalid arguments,
+    unauthorized ids) raise :class:`ApiError`, which ``loop._run_readonly`` —
+    the single conversion point — renders as ``"Error: ..."``. Informative
+    outcomes ("no matches", "folder not found, try ...") are ordinary results
+    and are returned as plain strings for the model to reason about.
+    """
     if name == "list_tree":
         path = args.get("path")
         start_path = path if isinstance(path, str) and path.strip() else "/"

--- a/backend/app/agent/tools.py
+++ b/backend/app/agent/tools.py
@@ -21,6 +21,7 @@ from ..errors import ApiError
 from ..models import File, Folder
 from ..services import ROOT_FOLDER_ID, require_owned_file
 from .extract import MAX_READ_BYTES, extract_text
+from .pathutil import find_child_folder, path_segments
 
 # Caps so one tool result can't blow the model's context on a large drive.
 MAX_TREE_NODES = 2000
@@ -213,7 +214,7 @@ def _list_tree(db: Session, owner_id: str, start_path: str = "/", max_depth: int
                 return
             emit(f"{path}/{file.filename}  [file id={file.id} type={file.content_type} size={file.size}]")
 
-    base = "" if start_id == ROOT_FOLDER_ID else "/" + "/".join(_path_segments(start_path))
+    base = "" if start_id == ROOT_FOLDER_ID else "/" + "/".join(path_segments(start_path))
     walk(start_id, base, 1)
 
     if not lines:
@@ -224,27 +225,15 @@ def _list_tree(db: Session, owner_id: str, start_path: str = "/", max_depth: int
     return out
 
 
-def _path_segments(path: str | None) -> list[str]:
-    if not path:
-        return []
-    return [seg for seg in path.replace("\\", "/").split("/") if seg and seg != "."]
-
-
 def _resolve_existing_folder_id(db: Session, owner_id: str, path: str | None) -> str | None:
     """Resolve a '/'-relative path to an owned folder id (ROOT for '/'); None if
     any segment doesn't exist."""
-    segments = _path_segments(path)
+    segments = path_segments(path)
     if any(seg == ".." for seg in segments):
         return None
     current = ROOT_FOLDER_ID
     for seg in segments:
-        folder = db.execute(
-            select(Folder).where(
-                Folder.owner_id == owner_id,
-                Folder.parent_folder_id == current,
-                func.lower(Folder.name) == seg.lower(),
-            )
-        ).scalars().first()
+        folder = find_child_folder(db, owner_id, current, seg)
         if folder is None:
             return None
         current = folder.id

--- a/backend/app/archive.py
+++ b/backend/app/archive.py
@@ -11,7 +11,6 @@ import logging
 import queue
 import threading
 import zipfile
-from collections import deque
 from os.path import splitext
 
 from sqlalchemy import select
@@ -20,6 +19,7 @@ from . import storage
 from .config import settings
 from .database import SessionLocal
 from .models import ArchiveJob, File, Folder
+from .services import collect_subtree
 from .utils import now_utc
 
 logger = logging.getLogger("archive")
@@ -130,18 +130,9 @@ def _collect_files(db, owner_id, file_ids, folder_ids) -> list[File]:
 
 
 def _collect_folder(db, owner_id, root_id, files_by_id) -> None:
-    pending = deque([root_id])
-    while pending:
-        parent_id = pending.popleft()
-        children = db.execute(
-            select(Folder).where(Folder.owner_id == owner_id, Folder.parent_folder_id == parent_id)
-        ).scalars().all()
-        for child in children:
-            pending.append(child.id)
-        for file in db.execute(
-            select(File).where(File.owner_id == owner_id, File.parent_folder_id == parent_id)
-        ).scalars().all():
-            files_by_id.setdefault(file.id, file)
+    _, files = collect_subtree(db, owner_id, root_id)
+    for file in files:
+        files_by_id.setdefault(file.id, file)
 
 
 # --- ZIP assembly -----------------------------------------------------------

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,11 @@ from typing import Annotated, Literal
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
+# Single source of truth for the agent's provider defaults; app.agent.config
+# reuses these for its empty-string fallbacks.
+DEFAULT_AGENT_MODEL = "qwen/qwen3.6-27b"
+DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="DRIVE_", env_file=".env", extra="ignore")
@@ -90,8 +95,8 @@ class Settings(BaseSettings):
     # POST /v2/agent/chat returns 400). Reading a file's contents sends its text
     # to the configured model provider, so the feature is strictly opt-in.
     openrouter_api_key: str = ""
-    agent_model: str = "qwen/qwen3.6-27b"
-    openrouter_base_url: str = "https://openrouter.ai/api/v1"
+    agent_model: str = DEFAULT_AGENT_MODEL
+    openrouter_base_url: str = DEFAULT_OPENROUTER_BASE_URL
     agent_max_steps: int = 8
 
     # Behaviour

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -10,7 +10,11 @@ from .database import get_db
 from .errors import ApiError
 from .security import decode_access_token
 
-__all__ = ["get_db", "CurrentUser", "get_current_user"]
+__all__ = ["get_db", "CurrentUser", "get_current_user", "IdempotencyKey"]
+
+# Shared parameter default for the Idempotency-Key header, so every mutating
+# route declares it identically: `idempotency_key: str | None = IdempotencyKey`.
+IdempotencyKey = Header(default=None, alias="Idempotency-Key")
 
 
 @dataclass(frozen=True)

--- a/backend/app/idempotency.py
+++ b/backend/app/idempotency.py
@@ -11,6 +11,7 @@ import hashlib
 from collections.abc import Callable
 from datetime import timedelta
 
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from .config import settings
@@ -18,6 +19,19 @@ from .models import IdempotencyRecord
 from .utils import now_utc
 
 ActionResult = tuple[int, dict]
+
+
+def idempotent_response(
+    db: Session,
+    user_id: str,
+    scope: str,
+    idempotency_key: str | None,
+    action: Callable[[], ActionResult],
+) -> JSONResponse:
+    """Run ``action`` under :func:`run_idempotent` and wrap the ``(status,
+    body)`` result as JSON — the shared tail of every mutating route."""
+    status_code, body = run_idempotent(db, user_id, scope, idempotency_key, action)
+    return JSONResponse(status_code=status_code, content=body)
 
 
 def _record_id(user_id: str, scope: str, key: str) -> str:

--- a/backend/app/pagination.py
+++ b/backend/app/pagination.py
@@ -8,6 +8,7 @@ integer offset, which is sufficient for the stable orderings used here.
 from __future__ import annotations
 
 import base64
+from collections.abc import Callable
 
 
 def normalize_limit(raw: object, default: int = 100, max_value: int = 200) -> int:
@@ -32,3 +33,17 @@ def decode_cursor(cursor: str | None) -> int:
 
 def encode_cursor(offset: int) -> str:
     return base64.urlsafe_b64encode(str(offset).encode("ascii")).rstrip(b"=").decode("ascii")
+
+
+def page_params(limit: object, cursor: str | None, *, default: int) -> tuple[int, int]:
+    """Resolve raw ``limit``/``cursor`` query params into ``(page_size, offset)``."""
+    return normalize_limit(limit, default=default, max_value=200), decode_cursor(cursor)
+
+
+def page_response(rows: list, page_size: int, offset: int, serialize: Callable[[object], dict]) -> dict:
+    """Assemble the ``{items, nextCursor}`` page from a ``page_size + 1`` fetch:
+    the extra row only signals that another page exists."""
+    has_more = len(rows) > page_size
+    items = [serialize(row) for row in rows[:page_size]]
+    next_cursor = encode_cursor(offset + page_size) if has_more else None
+    return {"items": items, "nextCursor": next_cursor}

--- a/backend/app/pagination.py
+++ b/backend/app/pagination.py
@@ -8,7 +8,10 @@ integer offset, which is sufficient for the stable orderings used here.
 from __future__ import annotations
 
 import base64
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
 
 
 def normalize_limit(raw: object, default: int = 100, max_value: int = 200) -> int:
@@ -40,7 +43,7 @@ def page_params(limit: object, cursor: str | None, *, default: int) -> tuple[int
     return normalize_limit(limit, default=default, max_value=200), decode_cursor(cursor)
 
 
-def page_response(rows: list, page_size: int, offset: int, serialize: Callable[[object], dict]) -> dict:
+def page_response(rows: Sequence[T], page_size: int, offset: int, serialize: Callable[[T], dict]) -> dict:
     """Assemble the ``{items, nextCursor}`` page from a ``page_size + 1`` fetch:
     the extra row only signals that another page exists."""
     has_more = len(rows) > page_size

--- a/backend/app/permissions.py
+++ b/backend/app/permissions.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-VALID_SHARE_PERMISSIONS = ("read", "download", "edit")
+from typing import Literal, get_args
+
+SharePermission = Literal["read", "download", "edit"]
+
+VALID_SHARE_PERMISSIONS: tuple[str, ...] = get_args(SharePermission)
 _DOWNLOADABLE = ("download", "edit")
 
 

--- a/backend/app/principals.py
+++ b/backend/app/principals.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, get_args
 
 if TYPE_CHECKING:
     from .deps import CurrentUser
 
-PrincipalType = str  # "email" | "user_sub"
-_VALID_TYPES = ("email", "user_sub")
+PrincipalType = Literal["email", "user_sub"]
+_VALID_TYPES: tuple[str, ...] = get_args(PrincipalType)
 
 
 def _infer_principal_type(value: str) -> PrincipalType:

--- a/backend/app/principals.py
+++ b/backend/app/principals.py
@@ -2,12 +2,27 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .deps import CurrentUser
+
 PrincipalType = str  # "email" | "user_sub"
 _VALID_TYPES = ("email", "user_sub")
 
 
-def infer_principal_type(value: str) -> PrincipalType:
+def _infer_principal_type(value: str) -> PrincipalType:
     return "email" if "@" in value else "user_sub"
+
+
+def user_principals(user: CurrentUser) -> list[tuple[str, str]]:
+    """The share principals the current user matches: their stable id, plus
+    their email when it differs. The single definition of that rule, shared by
+    the download check and the inbound-shares listing."""
+    principals = [("user_sub", user.id)]
+    if user.email and user.email != user.id:
+        principals.append(("email", user.email))
+    return principals
 
 
 def parse_principal_path(value: str | None) -> tuple[str | None, str | None]:
@@ -28,4 +43,4 @@ def parse_principal_path(value: str | None) -> tuple[str | None, str | None]:
     raw = value.strip()
     if not raw:
         return None, None
-    return infer_principal_type(raw), raw
+    return _infer_principal_type(raw), raw

--- a/backend/app/routers/archive.py
+++ b/backend/app/routers/archive.py
@@ -15,7 +15,7 @@ from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
 from ..idempotency import idempotent_response
 from ..models import ArchiveJob
-from ..schemas import CreateArchiveRequest
+from ..schemas import ArchiveQueuedOut, CreateArchiveRequest
 from ..utils import iso, now_utc
 
 router = APIRouter(prefix="/v2/download/archives", tags=["archive"])
@@ -60,7 +60,7 @@ def create_archive(
         db.flush()
         db.commit()  # persist before the worker (separate session) picks it up
         archive.enqueue(job.id)
-        return 202, {"archiveJobId": job.id, "status": "queued"}
+        return 202, ArchiveQueuedOut(archiveJobId=job.id, status="queued").model_dump()
 
     return idempotent_response(db, user.id, "archive-queue", idempotency_key, action)
 

--- a/backend/app/routers/archive.py
+++ b/backend/app/routers/archive.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from .. import archive
 from ..blob_links import build_download_url
 from ..config import settings
-from ..deps import CurrentUser, get_current_user, get_db
+from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
-from ..idempotency import run_idempotent
+from ..idempotency import idempotent_response
 from ..models import ArchiveJob
 from ..schemas import CreateArchiveRequest
 from ..utils import iso, now_utc
@@ -41,7 +41,7 @@ def create_archive(
     payload: CreateArchiveRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         file_ids = _dedupe(payload.fileIds)
@@ -62,8 +62,7 @@ def create_archive(
         archive.enqueue(job.id)
         return 202, {"archiveJobId": job.id, "status": "queued"}
 
-    status, body = run_idempotent(db, user.id, "archive-queue", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, "archive-queue", idempotency_key, action)
 
 
 @router.get("/{archive_job_id}")

--- a/backend/app/routers/download.py
+++ b/backend/app/routers/download.py
@@ -11,6 +11,7 @@ from ..config import settings
 from ..deps import CurrentUser, get_current_user, get_db
 from ..errors import ApiError
 from ..permissions import can_download
+from ..principals import user_principals
 from ..services import active_share, get_file
 from ..utils import iso
 
@@ -31,10 +32,7 @@ def issue_download_url(
     is_owner = file.owner_id == user.id
     share = None
     if not is_owner:
-        principals = [("user_sub", user.id)]
-        if user.email and user.email != user.id:
-            principals.append(("email", user.email))
-        share = active_share(db, file_id, principals)
+        share = active_share(db, file_id, user_principals(user))
         if share is None:
             raise ApiError(403, "Access denied")
         if not can_download(share.permission):

--- a/backend/app/routers/download.py
+++ b/backend/app/routers/download.py
@@ -34,15 +34,20 @@ def issue_download_url(
     if not is_owner:
         share = active_share(db, file_id, user_principals(user))
         if share is None:
-            raise ApiError(403, "Access denied")
+            # No share at all: hide the file's existence entirely. A share
+            # with the wrong permission stays 403 — that caller already
+            # provably knows the file exists.
+            raise ApiError(404, "File not found")
         if not can_download(share.permission):
             raise ApiError(403, "Insufficient share permission for download")
 
     if not storage.exists(file.storage_key):
         raise ApiError(404, "File not found in storage")
     if file.status != "ready":
-        file.status = "ready"
-        db.flush()
+        # A file that skipped finalize has not passed the antivirus scan or
+        # quota re-check, so refuse rather than silently marking it ready
+        # (matching the public-download behaviour).
+        raise ApiError(409, "File is not ready for download")
 
     out = {
         "downloadUrl": build_download_url(request, file.storage_key, file.filename),

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -13,7 +13,15 @@ from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
 from ..idempotency import idempotent_response
 from ..models import File
-from ..schemas import CreateUploadRequest, PatchFileRequest
+from ..schemas import (
+    CreateUploadRequest,
+    DeleteFileOut,
+    FinalizeOut,
+    MessageOut,
+    PatchFileOut,
+    PatchFileRequest,
+    UploadCreateOut,
+)
 from ..services import (
     folder_exists_for_owner,
     move_or_rename_file_core,
@@ -78,12 +86,12 @@ def create_upload(
         file.storage_key = storage.file_key(user.id, file.id, file.filename)
         db.flush()
 
-        return 201, {
-            "fileId": file.id,
-            "uploadUrl": build_upload_url(request, file.storage_key),
-            "expiresIn": settings.signed_url_expiry_seconds,
-            "status": "pending",
-        }
+        return 201, UploadCreateOut(
+            fileId=file.id,
+            uploadUrl=build_upload_url(request, file.storage_key),
+            expiresIn=settings.signed_url_expiry_seconds,
+            status="pending",
+        ).model_dump()
 
     return idempotent_response(db, user.id, "files-upload-create", idempotency_key, action)
 
@@ -119,12 +127,12 @@ def finalize_upload(
             file.size = actual_size
             db.flush()
 
-        return 200, {
-            "fileId": file.id,
-            "status": "ready",
-            "size": actual_size,
-            "contentType": file.content_type,
-        }
+        return 200, FinalizeOut(
+            fileId=file.id,
+            status="ready",
+            size=actual_size,
+            contentType=file.content_type,
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"files-finalize-{file_id}", idempotency_key, action)
 
@@ -149,13 +157,13 @@ def patch_file(
             dest_folder_id=payload.destinationFolderId,
         )
         if not changed:
-            return 200, {"message": "No changes"}
-        return 200, {
-            "message": "File updated",
-            "fileId": file.id,
-            "filename": file.filename,
-            "parentFolderId": file.parent_folder_id,
-        }
+            return 200, MessageOut(message="No changes").model_dump()
+        return 200, PatchFileOut(
+            message="File updated",
+            fileId=file.id,
+            filename=file.filename,
+            parentFolderId=file.parent_folder_id,
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"files-patch-{file_id}", idempotency_key, action)
 
@@ -172,6 +180,6 @@ def delete_file(
         storage.delete(file.storage_key)
         db.delete(file)  # cascades to shares + public links
         db.flush()
-        return 200, {"message": "File deleted", "fileId": file_id}
+        return 200, DeleteFileOut(message="File deleted", fileId=file_id).model_dump()
 
     return idempotent_response(db, user.id, f"files-delete-{file_id}", idempotency_key, action)

--- a/backend/app/routers/files.py
+++ b/backend/app/routers/files.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from .. import antivirus, storage
 from ..blob_links import build_upload_url
 from ..config import settings
-from ..deps import CurrentUser, get_current_user, get_db
+from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
-from ..idempotency import run_idempotent
+from ..idempotency import idempotent_response
 from ..models import File
 from ..schemas import CreateUploadRequest, PatchFileRequest
 from ..services import (
@@ -40,7 +40,7 @@ def create_upload(
     request: Request,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         if not is_valid_name(payload.filename):
@@ -85,8 +85,7 @@ def create_upload(
             "status": "pending",
         }
 
-    status, body = run_idempotent(db, user.id, "files-upload-create", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, "files-upload-create", idempotency_key, action)
 
 
 @router.post("/{file_id}/finalize")
@@ -94,7 +93,7 @@ def finalize_upload(
     file_id: str,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         file = require_owned_file(db, user.id, file_id)
@@ -127,8 +126,7 @@ def finalize_upload(
             "contentType": file.content_type,
         }
 
-    status, body = run_idempotent(db, user.id, f"files-finalize-{file_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"files-finalize-{file_id}", idempotency_key, action)
 
 
 @router.patch("/{file_id}")
@@ -137,7 +135,7 @@ def patch_file(
     payload: PatchFileRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         if payload.newName is None and payload.destinationFolderId is None:
@@ -159,8 +157,7 @@ def patch_file(
             "parentFolderId": file.parent_folder_id,
         }
 
-    status, body = run_idempotent(db, user.id, f"files-patch-{file_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"files-patch-{file_id}", idempotency_key, action)
 
 
 @router.delete("/{file_id}")
@@ -168,7 +165,7 @@ def delete_file(
     file_id: str,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         file = require_owned_file(db, user.id, file_id)
@@ -177,5 +174,4 @@ def delete_file(
         db.flush()
         return 200, {"message": "File deleted", "fileId": file_id}
 
-    status, body = run_idempotent(db, user.id, f"files-delete-{file_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"files-delete-{file_id}", idempotency_key, action)

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -48,14 +48,23 @@ def list_children(
         raise ApiError(404, "Folder not found")
 
     page_size, offset = page_params(limit, cursor, default=100)
-    fetch = page_size + 1  # one extra row tells us whether another page exists
+    rows = _children_window(db, user.id, folder_id, offset, page_size + 1)
 
-    # Folders sort before files in the combined stream. Page across both tables
-    # at the DB level (LIMIT/OFFSET) so we never load a whole folder in memory.
+    page_file_ids = [row.id for row in rows[:page_size] if isinstance(row, File)]
+    flags = derive_file_flags(db, page_file_ids)
+
+    return page_response(rows, page_size, offset, lambda row: _serialize_child(row, flags))
+
+
+def _children_window(db: Session, user_id: str, folder_id: str, offset: int, fetch: int) -> list:
+    """Fetch ``fetch`` rows of the folders-then-files stream starting at
+    ``offset``. Folders sort before files in the combined stream; paging runs
+    across both tables at the DB level (LIMIT/OFFSET) so a whole folder is
+    never loaded into memory."""
     folder_count = db.scalar(
         select(func.count())
         .select_from(Folder)
-        .where(Folder.owner_id == user.id, Folder.parent_folder_id == folder_id)
+        .where(Folder.owner_id == user_id, Folder.parent_folder_id == folder_id)
     ) or 0
 
     rows: list = []
@@ -63,7 +72,7 @@ def list_children(
         rows.extend(
             db.execute(
                 select(Folder)
-                .where(Folder.owner_id == user.id, Folder.parent_folder_id == folder_id)
+                .where(Folder.owner_id == user_id, Folder.parent_folder_id == folder_id)
                 .order_by(func.lower(Folder.name), Folder.id)
                 .offset(offset)
                 .limit(fetch)
@@ -76,17 +85,13 @@ def list_children(
         rows.extend(
             db.execute(
                 select(File)
-                .where(File.owner_id == user.id, File.parent_folder_id == folder_id)
+                .where(File.owner_id == user_id, File.parent_folder_id == folder_id)
                 .order_by(func.lower(File.filename), File.id)
                 .offset(file_offset)
                 .limit(remaining)
             ).scalars().all()
         )
-
-    page_file_ids = [row.id for row in rows[:page_size] if isinstance(row, File)]
-    flags = derive_file_flags(db, page_file_ids)
-
-    return page_response(rows, page_size, offset, lambda row: _serialize_child(row, flags))
+    return rows
 
 
 def _serialize_child(row: Folder | File, flags: dict[str, dict[str, bool]]) -> dict:

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -2,21 +2,20 @@
 
 from __future__ import annotations
 
-from collections import deque
-
-from fastapi import APIRouter, Depends, Header, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from .. import storage
-from ..deps import CurrentUser, get_current_user, get_db
+from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
-from ..idempotency import run_idempotent
+from ..idempotency import idempotent_response
 from ..models import File, Folder
-from ..pagination import decode_cursor, encode_cursor, normalize_limit
+from ..pagination import page_params, page_response
 from ..schemas import CreateFolderRequest, PatchFolderRequest
 from ..services import (
+    collect_subtree,
     create_folder_core,
     derive_file_flags,
     folder_exists_for_owner,
@@ -39,8 +38,7 @@ def list_children(
     if not folder_exists_for_owner(db, user.id, folder_id):
         raise ApiError(404, "Folder not found")
 
-    page_size = normalize_limit(limit, default=100, max_value=200)
-    offset = decode_cursor(cursor)
+    page_size, offset = page_params(limit, cursor, default=100)
     fetch = page_size + 1  # one extra row tells us whether another page exists
 
     # Folders sort before files in the combined stream. Page across both tables
@@ -76,40 +74,35 @@ def list_children(
             ).scalars().all()
         )
 
-    has_more = len(rows) > page_size
-    window = rows[:page_size]
-
-    page_file_ids = [row.id for row in window if isinstance(row, File)]
+    page_file_ids = [row.id for row in rows[:page_size] if isinstance(row, File)]
     flags = derive_file_flags(db, page_file_ids)
 
-    items: list[dict] = []
-    for row in window:
-        if isinstance(row, Folder):
-            items.append({
-                "type": "folder",
-                "folderId": row.id,
-                "name": row.name,
-                "parentFolderId": row.parent_folder_id,
-                "createdAt": iso(row.created_at),
-                "updatedAt": iso(row.updated_at),
-            })
-        else:
-            items.append({
-                "type": "file",
-                "fileId": row.id,
-                "name": row.filename,
-                "parentFolderId": row.parent_folder_id,
-                "size": row.size,
-                "contentType": row.content_type,
-                "status": row.status,
-                "isShared": flags[row.id]["isShared"],
-                "hasPublicLink": flags[row.id]["hasPublicLink"],
-                "createdAt": iso(row.created_at),
-                "updatedAt": iso(row.updated_at),
-            })
+    return page_response(rows, page_size, offset, lambda row: _serialize_child(row, flags))
 
-    next_cursor = encode_cursor(offset + page_size) if has_more else None
-    return {"items": items, "nextCursor": next_cursor}
+
+def _serialize_child(row: Folder | File, flags: dict[str, dict[str, bool]]) -> dict:
+    if isinstance(row, Folder):
+        return {
+            "type": "folder",
+            "folderId": row.id,
+            "name": row.name,
+            "parentFolderId": row.parent_folder_id,
+            "createdAt": iso(row.created_at),
+            "updatedAt": iso(row.updated_at),
+        }
+    return {
+        "type": "file",
+        "fileId": row.id,
+        "name": row.filename,
+        "parentFolderId": row.parent_folder_id,
+        "size": row.size,
+        "contentType": row.content_type,
+        "status": row.status,
+        "isShared": flags[row.id]["isShared"],
+        "hasPublicLink": flags[row.id]["hasPublicLink"],
+        "createdAt": iso(row.created_at),
+        "updatedAt": iso(row.updated_at),
+    }
 
 
 @router.post("/{folder_id}/folders", status_code=201)
@@ -118,14 +111,13 @@ def create_folder(
     payload: CreateFolderRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         folder = create_folder_core(db, user.id, folder_id, payload.name or payload.folderName)
         return 201, {"folderId": folder.id, "name": folder.name, "parentFolderId": folder_id}
 
-    status, body = run_idempotent(db, user.id, f"folders-create-{folder_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"folders-create-{folder_id}", idempotency_key, action)
 
 
 @router.patch("/{folder_id}")
@@ -134,7 +126,7 @@ def patch_folder(
     payload: PatchFolderRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         if payload.newName is None and payload.destinationFolderId is None:
@@ -156,8 +148,7 @@ def patch_folder(
             "parentFolderId": folder.parent_folder_id,
         }
 
-    status, body = run_idempotent(db, user.id, f"folders-patch-{folder_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"folders-patch-{folder_id}", idempotency_key, action)
 
 
 @router.delete("/{folder_id}")
@@ -166,7 +157,7 @@ def delete_folder(
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
     recursive: bool = Query(default=False),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         folder = require_owned_folder(db, user.id, folder_id)
@@ -197,25 +188,8 @@ def delete_folder(
                 "deletedFiles": 0,
             }
 
-        folders_to_delete = [folder]
-        files_to_delete: list[File] = []
-        queue = deque([folder_id])
-        while queue:
-            parent_id = queue.popleft()
-            child_folders = db.execute(
-                select(Folder).where(
-                    Folder.owner_id == user.id, Folder.parent_folder_id == parent_id
-                )
-            ).scalars().all()
-            for child in child_folders:
-                folders_to_delete.append(child)
-                queue.append(child.id)
-            child_files = db.execute(
-                select(File).where(
-                    File.owner_id == user.id, File.parent_folder_id == parent_id
-                )
-            ).scalars().all()
-            files_to_delete.extend(child_files)
+        sub_folders, files_to_delete = collect_subtree(db, user.id, folder_id)
+        folders_to_delete = [folder, *sub_folders]
 
         for file in files_to_delete:
             storage.delete(file.storage_key)
@@ -232,5 +206,4 @@ def delete_folder(
             "deletedFiles": len(files_to_delete),
         }
 
-    status, body = run_idempotent(db, user.id, f"folders-delete-{folder_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"folders-delete-{folder_id}", idempotency_key, action)

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -13,7 +13,16 @@ from ..errors import ApiError
 from ..idempotency import idempotent_response
 from ..models import File, Folder
 from ..pagination import page_params, page_response
-from ..schemas import CreateFolderRequest, PatchFolderRequest
+from ..schemas import (
+    ChildFileOut,
+    ChildFolderOut,
+    CreateFolderOut,
+    CreateFolderRequest,
+    DeleteFolderOut,
+    MessageOut,
+    PatchFolderOut,
+    PatchFolderRequest,
+)
 from ..services import (
     collect_subtree,
     create_folder_core,
@@ -82,27 +91,25 @@ def list_children(
 
 def _serialize_child(row: Folder | File, flags: dict[str, dict[str, bool]]) -> dict:
     if isinstance(row, Folder):
-        return {
-            "type": "folder",
-            "folderId": row.id,
-            "name": row.name,
-            "parentFolderId": row.parent_folder_id,
-            "createdAt": iso(row.created_at),
-            "updatedAt": iso(row.updated_at),
-        }
-    return {
-        "type": "file",
-        "fileId": row.id,
-        "name": row.filename,
-        "parentFolderId": row.parent_folder_id,
-        "size": row.size,
-        "contentType": row.content_type,
-        "status": row.status,
-        "isShared": flags[row.id]["isShared"],
-        "hasPublicLink": flags[row.id]["hasPublicLink"],
-        "createdAt": iso(row.created_at),
-        "updatedAt": iso(row.updated_at),
-    }
+        return ChildFolderOut(
+            folderId=row.id,
+            name=row.name,
+            parentFolderId=row.parent_folder_id,
+            createdAt=iso(row.created_at),
+            updatedAt=iso(row.updated_at),
+        ).model_dump()
+    return ChildFileOut(
+        fileId=row.id,
+        filename=row.filename,
+        parentFolderId=row.parent_folder_id,
+        size=row.size,
+        contentType=row.content_type,
+        status=row.status,
+        isShared=flags[row.id]["isShared"],
+        hasPublicLink=flags[row.id]["hasPublicLink"],
+        createdAt=iso(row.created_at),
+        updatedAt=iso(row.updated_at),
+    ).model_dump()
 
 
 @router.post("/{folder_id}/folders", status_code=201)
@@ -114,8 +121,10 @@ def create_folder(
     idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
-        folder = create_folder_core(db, user.id, folder_id, payload.name or payload.folderName)
-        return 201, {"folderId": folder.id, "name": folder.name, "parentFolderId": folder_id}
+        folder = create_folder_core(db, user.id, folder_id, payload.name)
+        return 201, CreateFolderOut(
+            folderId=folder.id, name=folder.name, parentFolderId=folder_id
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"folders-create-{folder_id}", idempotency_key, action)
 
@@ -140,13 +149,13 @@ def patch_folder(
             dest_folder_id=payload.destinationFolderId,
         )
         if not changed:
-            return 200, {"message": "No changes"}
-        return 200, {
-            "message": "Folder updated",
-            "folderId": folder.id,
-            "name": folder.name,
-            "parentFolderId": folder.parent_folder_id,
-        }
+            return 200, MessageOut(message="No changes").model_dump()
+        return 200, PatchFolderOut(
+            message="Folder updated",
+            folderId=folder.id,
+            name=folder.name,
+            parentFolderId=folder.parent_folder_id,
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"folders-patch-{folder_id}", idempotency_key, action)
 
@@ -180,13 +189,13 @@ def delete_folder(
                 )
             db.delete(folder)
             db.flush()
-            return 200, {
-                "message": "Folder deleted",
-                "folderId": folder_id,
-                "recursive": False,
-                "deletedFolders": 1,
-                "deletedFiles": 0,
-            }
+            return 200, DeleteFolderOut(
+                message="Folder deleted",
+                folderId=folder_id,
+                recursive=False,
+                deletedFolders=1,
+                deletedFiles=0,
+            ).model_dump()
 
         sub_folders, files_to_delete = collect_subtree(db, user.id, folder_id)
         folders_to_delete = [folder, *sub_folders]
@@ -198,12 +207,12 @@ def delete_folder(
             db.delete(fld)
         db.flush()
 
-        return 200, {
-            "message": "Folder deleted",
-            "folderId": folder_id,
-            "recursive": True,
-            "deletedFolders": len(folders_to_delete),
-            "deletedFiles": len(files_to_delete),
-        }
+        return 200, DeleteFolderOut(
+            message="Folder deleted",
+            folderId=folder_id,
+            recursive=True,
+            deletedFolders=len(folders_to_delete),
+            deletedFiles=len(files_to_delete),
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"folders-delete-{folder_id}", idempotency_key, action)

--- a/backend/app/routers/folders.py
+++ b/backend/app/routers/folders.py
@@ -56,7 +56,9 @@ def list_children(
     return page_response(rows, page_size, offset, lambda row: _serialize_child(row, flags))
 
 
-def _children_window(db: Session, user_id: str, folder_id: str, offset: int, fetch: int) -> list:
+def _children_window(
+    db: Session, user_id: str, folder_id: str, offset: int, fetch: int
+) -> list[Folder | File]:
     """Fetch ``fetch`` rows of the folders-then-files stream starting at
     ``offset``. Folders sort before files in the combined stream; paging runs
     across both tables at the DB level (LIMIT/OFFSET) so a whole folder is
@@ -67,7 +69,7 @@ def _children_window(db: Session, user_id: str, folder_id: str, offset: int, fet
         .where(Folder.owner_id == user_id, Folder.parent_folder_id == folder_id)
     ) or 0
 
-    rows: list = []
+    rows: list[Folder | File] = []
     if offset < folder_count:
         rows.extend(
             db.execute(

--- a/backend/app/routers/public_links.py
+++ b/backend/app/routers/public_links.py
@@ -2,36 +2,22 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
-from fastapi import APIRouter, Depends, Header, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from ..config import settings
-from ..deps import CurrentUser, get_current_user, get_db
+from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
-from ..idempotency import run_idempotent
+from ..idempotency import idempotent_response
 from ..models import PublicLink
-from ..pagination import decode_cursor, encode_cursor, normalize_limit
+from ..pagination import page_params, page_response
 from ..schemas import CreatePublicLinkRequest, PatchPublicLinkRequest
 from ..security import hash_password
-from ..services import require_owned_file
+from ..services import active_window, expiry_from_days, require_owned_file
 from ..utils import iso, now_utc
 
 router = APIRouter(tags=["public-links"])
-
-
-def _expiry_from_days(days: int | None):
-    resolved = settings.share_expiry_days if days is None else days
-    try:
-        resolved = int(resolved)
-    except (TypeError, ValueError):
-        raise ApiError(400, "expiryDays must be an integer") from None
-    if resolved < 1 or resolved > 365:
-        raise ApiError(400, "expiryDays must be between 1 and 365")
-    return now_utc() + timedelta(days=resolved)
 
 
 def _require_owned_link(db: Session, user_id: str, token: str) -> PublicLink:
@@ -49,11 +35,11 @@ def create_public_link(
     payload: CreatePublicLinkRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         file = require_owned_file(db, user.id, file_id)
-        expires_at = _expiry_from_days(payload.expiryDays)
+        expires_at = expiry_from_days(payload.expiryDays)
 
         link = PublicLink(
             file_id=file_id,
@@ -73,8 +59,7 @@ def create_public_link(
             "expiresAt": iso(expires_at),
         }
 
-    status, body = run_idempotent(db, user.id, f"public-links-create-{file_id}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"public-links-create-{file_id}", idempotency_key, action)
 
 
 @router.get("/v2/files/{file_id}/public-links")
@@ -86,24 +71,24 @@ def list_public_links(
     cursor: str | None = Query(default=None),
 ) -> dict:
     require_owned_file(db, user.id, file_id)
-    page_size = normalize_limit(limit, default=50, max_value=200)
-    offset = decode_cursor(cursor)
+    page_size, offset = page_params(limit, cursor, default=50)
 
-    now = now_utc()
     links = db.execute(
         select(PublicLink)
         .where(
             PublicLink.file_id == file_id,
-            or_(PublicLink.expires_at.is_(None), PublicLink.expires_at > now),
+            active_window(PublicLink.expires_at, now_utc()),
         )
         .order_by(PublicLink.created_at, PublicLink.token)
         .offset(offset)
         .limit(page_size + 1)
     ).scalars().all()
 
-    has_more = len(links) > page_size
-    items = [
-        {
+    return page_response(
+        links,
+        page_size,
+        offset,
+        lambda link: {
             "token": link.token,
             "fileId": link.file_id,
             "filename": link.file.filename if link.file else None,
@@ -112,11 +97,8 @@ def list_public_links(
             "createdAt": iso(link.created_at),
             "updatedAt": iso(link.updated_at),
             "expiresAt": iso(link.expires_at),
-        }
-        for link in links[:page_size]
-    ]
-    next_cursor = encode_cursor(offset + page_size) if has_more else None
-    return {"items": items, "nextCursor": next_cursor}
+        },
+    )
 
 
 @router.patch("/v2/public-links/{token}")
@@ -125,7 +107,7 @@ def patch_public_link(
     payload: PatchPublicLinkRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         link = _require_owned_link(db, user.id, token)
@@ -137,7 +119,7 @@ def patch_public_link(
             link.password_hash = None
             changed = True
         if payload.expiryDays is not None:
-            link.expires_at = _expiry_from_days(payload.expiryDays)
+            link.expires_at = expiry_from_days(payload.expiryDays)
             changed = True
         if not changed:
             raise ApiError(400, "Nothing to update")
@@ -148,8 +130,7 @@ def patch_public_link(
             "expiresAt": iso(link.expires_at),
         }
 
-    status, body = run_idempotent(db, user.id, f"public-links-patch-{token}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"public-links-patch-{token}", idempotency_key, action)
 
 
 @router.delete("/v2/public-links/{token}")
@@ -157,7 +138,7 @@ def delete_public_link(
     token: str,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
         link = _require_owned_link(db, user.id, token)
@@ -165,5 +146,4 @@ def delete_public_link(
         db.flush()
         return 200, {"message": "Public link deleted", "token": token}
 
-    status, body = run_idempotent(db, user.id, f"public-links-delete-{token}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"public-links-delete-{token}", idempotency_key, action)

--- a/backend/app/routers/public_links.py
+++ b/backend/app/routers/public_links.py
@@ -28,11 +28,10 @@ router = APIRouter(tags=["public-links"])
 
 
 def _require_owned_link(db: Session, user_id: str, token: str) -> PublicLink:
+    """Another tenant's link answers 404, matching the owned file/folder checks."""
     link = db.get(PublicLink, token)
-    if link is None:
+    if link is None or link.owner_id != user_id:
         raise ApiError(404, "Public link not found")
-    if link.owner_id != user_id:
-        raise ApiError(403, "Access denied")
     return link
 
 

--- a/backend/app/routers/public_links.py
+++ b/backend/app/routers/public_links.py
@@ -12,7 +12,14 @@ from ..errors import ApiError
 from ..idempotency import idempotent_response
 from ..models import PublicLink
 from ..pagination import page_params, page_response
-from ..schemas import CreatePublicLinkRequest, PatchPublicLinkRequest
+from ..schemas import (
+    CreatePublicLinkRequest,
+    DeletePublicLinkOut,
+    PatchPublicLinkOut,
+    PatchPublicLinkRequest,
+    PublicLinkCreatedOut,
+    PublicLinkOut,
+)
 from ..security import hash_password
 from ..services import active_window, expiry_from_days, require_owned_file
 from ..utils import iso, now_utc
@@ -50,14 +57,14 @@ def create_public_link(
         )
         db.add(link)
         db.flush()
-        return 201, {
-            "token": link.token,
-            "fileId": file_id,
-            "filename": file.filename,
-            "hasPassword": bool(payload.password),
-            "downloadCount": 0,
-            "expiresAt": iso(expires_at),
-        }
+        return 201, PublicLinkCreatedOut(
+            token=link.token,
+            fileId=file_id,
+            filename=file.filename,
+            hasPassword=bool(payload.password),
+            downloadCount=0,
+            expiresAt=iso(expires_at),
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"public-links-create-{file_id}", idempotency_key, action)
 
@@ -88,16 +95,16 @@ def list_public_links(
         links,
         page_size,
         offset,
-        lambda link: {
-            "token": link.token,
-            "fileId": link.file_id,
-            "filename": link.file.filename if link.file else None,
-            "hasPassword": bool(link.password_hash),
-            "downloadCount": link.download_count,
-            "createdAt": iso(link.created_at),
-            "updatedAt": iso(link.updated_at),
-            "expiresAt": iso(link.expires_at),
-        },
+        lambda link: PublicLinkOut(
+            token=link.token,
+            fileId=link.file_id,
+            filename=link.file.filename if link.file else None,
+            hasPassword=bool(link.password_hash),
+            downloadCount=link.download_count,
+            createdAt=iso(link.created_at),
+            updatedAt=iso(link.updated_at),
+            expiresAt=iso(link.expires_at),
+        ).model_dump(),
     )
 
 
@@ -124,11 +131,11 @@ def patch_public_link(
         if not changed:
             raise ApiError(400, "Nothing to update")
         db.flush()
-        return 200, {
-            "token": token,
-            "hasPassword": bool(link.password_hash),
-            "expiresAt": iso(link.expires_at),
-        }
+        return 200, PatchPublicLinkOut(
+            token=token,
+            hasPassword=bool(link.password_hash),
+            expiresAt=iso(link.expires_at),
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"public-links-patch-{token}", idempotency_key, action)
 
@@ -144,6 +151,6 @@ def delete_public_link(
         link = _require_owned_link(db, user.id, token)
         db.delete(link)
         db.flush()
-        return 200, {"message": "Public link deleted", "token": token}
+        return 200, DeletePublicLinkOut(message="Public link deleted", token=token).model_dump()
 
     return idempotent_response(db, user.id, f"public-links-delete-{token}", idempotency_key, action)

--- a/backend/app/routers/shares.py
+++ b/backend/app/routers/shares.py
@@ -87,7 +87,7 @@ def list_inbound_shares(
         .limit(page_size + 1)
     ).all()
 
-    return page_response(rows, page_size, offset, lambda row: _serialize_inbound(*row))
+    return page_response(rows, page_size, offset, lambda row: _serialize_inbound(row[0], row[1]))
 
 
 @router.get("/v2/files/{file_id}/shares")

--- a/backend/app/routers/shares.py
+++ b/backend/app/routers/shares.py
@@ -2,37 +2,41 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-
-from fastapi import APIRouter, Depends, Header, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
-from ..config import settings
-from ..deps import CurrentUser, get_current_user, get_db
+from ..deps import CurrentUser, IdempotencyKey, get_current_user, get_db
 from ..errors import ApiError
-from ..idempotency import run_idempotent
+from ..idempotency import idempotent_response
 from ..models import File, Share
-from ..pagination import decode_cursor, encode_cursor, normalize_limit
+from ..pagination import page_params, page_response
 from ..permissions import is_valid_permission
-from ..principals import parse_principal_path
+from ..principals import parse_principal_path, user_principals
 from ..schemas import PatchShareRequest, PutShareRequest
-from ..services import require_owned_file
+from ..services import active_window, expiry_from_days, require_owned_file
 from ..utils import iso, now_utc
 
 router = APIRouter(tags=["shares"])
 
 
-def _expiry_from_days(days: int | None):
-    resolved = settings.share_expiry_days if days is None else days
-    try:
-        resolved = int(resolved)
-    except (TypeError, ValueError):
-        raise ApiError(400, "expiryDays must be an integer") from None
-    if resolved < 1 or resolved > 365:
-        raise ApiError(400, "expiryDays must be between 1 and 365")
-    return now_utc() + timedelta(days=resolved)
+def _parsed_principal(principal: str) -> tuple[str, str]:
+    """Parse the ``{principal}`` path segment or fail with the shared 400."""
+    principal_type, principal_value = parse_principal_path(principal)
+    if not principal_type or not principal_value:
+        raise ApiError(400, "Invalid principal format")
+    return principal_type, principal_value
+
+
+def _find_share(db: Session, file_id: str, principal_type: str, principal_value: str) -> Share | None:
+    return db.execute(
+        select(Share).where(
+            Share.file_id == file_id,
+            Share.principal_type == principal_type,
+            Share.principal_value == principal_value,
+        )
+    ).scalars().first()
 
 
 def _serialize_inbound(share: Share, file: File) -> dict:
@@ -57,30 +61,26 @@ def list_inbound_shares(
     limit: str | None = Query(default=None),
     cursor: str | None = Query(default=None),
 ) -> dict:
-    page_size = normalize_limit(limit, default=50, max_value=200)
-    offset = decode_cursor(cursor)
+    page_size, offset = page_params(limit, cursor, default=50)
 
-    principal_clauses = [(Share.principal_type == "user_sub") & (Share.principal_value == user.id)]
-    if user.email and user.email != user.id:
-        principal_clauses.append((Share.principal_type == "email") & (Share.principal_value == user.email))
+    principal_clauses = [
+        (Share.principal_type == ptype) & (Share.principal_value == pvalue)
+        for ptype, pvalue in user_principals(user)
+    ]
 
-    now = now_utc()
     rows = db.execute(
         select(Share, File)
         .join(File, Share.file_id == File.id)
         .where(
             or_(*principal_clauses),
-            or_(Share.expires_at.is_(None), Share.expires_at > now),
+            active_window(Share.expires_at, now_utc()),
         )
         .order_by(Share.shared_at.desc(), Share.id)
         .offset(offset)
         .limit(page_size + 1)
     ).all()
 
-    has_more = len(rows) > page_size
-    items = [_serialize_inbound(share, file) for share, file in rows[:page_size]]
-    next_cursor = encode_cursor(offset + page_size) if has_more else None
-    return {"items": items, "nextCursor": next_cursor}
+    return page_response(rows, page_size, offset, lambda row: _serialize_inbound(*row))
 
 
 @router.get("/v2/files/{file_id}/shares")
@@ -92,32 +92,29 @@ def list_file_shares(
     cursor: str | None = Query(default=None),
 ) -> dict:
     require_owned_file(db, user.id, file_id)
-    page_size = normalize_limit(limit, default=50, max_value=200)
-    offset = decode_cursor(cursor)
+    page_size, offset = page_params(limit, cursor, default=50)
 
-    now = now_utc()
     shares = db.execute(
         select(Share)
-        .where(Share.file_id == file_id, or_(Share.expires_at.is_(None), Share.expires_at > now))
+        .where(Share.file_id == file_id, active_window(Share.expires_at, now_utc()))
         .order_by(Share.shared_at, Share.id)
         .offset(offset)
         .limit(page_size + 1)
     ).scalars().all()
 
-    has_more = len(shares) > page_size
-    items = [
-        {
+    return page_response(
+        shares,
+        page_size,
+        offset,
+        lambda s: {
             "principalType": s.principal_type,
             "principalValue": s.principal_value,
             "principalDisplay": s.principal_display,
             "permission": s.permission,
             "sharedAt": iso(s.shared_at),
             "expiresAt": iso(s.expires_at),
-        }
-        for s in shares[:page_size]
-    ]
-    next_cursor = encode_cursor(offset + page_size) if has_more else None
-    return {"items": items, "nextCursor": next_cursor}
+        },
+    )
 
 
 @router.put("/v2/files/{file_id}/shares/{principal}")
@@ -127,26 +124,17 @@ def put_share(
     payload: PutShareRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
-        principal_type, principal_value = parse_principal_path(principal)
-        if not principal_type:
-            raise ApiError(400, "Invalid principal format")
+        principal_type, principal_value = _parsed_principal(principal)
         if not is_valid_permission(payload.permission):
             raise ApiError(400, "permission must be read, download, or edit")
 
         require_owned_file(db, user.id, file_id)
-        expires_at = _expiry_from_days(payload.expiryDays)
+        expires_at = expiry_from_days(payload.expiryDays)
 
-        share = db.execute(
-            select(Share).where(
-                Share.file_id == file_id,
-                Share.principal_type == principal_type,
-                Share.principal_value == principal_value,
-            )
-        ).scalars().first()
-
+        share = _find_share(db, file_id, principal_type, principal_value)
         if share is None:
             share = Share(
                 file_id=file_id,
@@ -169,8 +157,7 @@ def put_share(
             "expiresAt": iso(expires_at),
         }
 
-    status, body = run_idempotent(db, user.id, f"shares-put-{file_id}-{principal}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"shares-put-{file_id}-{principal}", idempotency_key, action)
 
 
 @router.patch("/v2/files/{file_id}/shares/{principal}")
@@ -180,21 +167,13 @@ def patch_share(
     payload: PatchShareRequest,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
-        principal_type, principal_value = parse_principal_path(principal)
-        if not principal_type:
-            raise ApiError(400, "Invalid principal format")
+        principal_type, principal_value = _parsed_principal(principal)
         require_owned_file(db, user.id, file_id)
 
-        share = db.execute(
-            select(Share).where(
-                Share.file_id == file_id,
-                Share.principal_type == principal_type,
-                Share.principal_value == principal_value,
-            )
-        ).scalars().first()
+        share = _find_share(db, file_id, principal_type, principal_value)
         if share is None:
             raise ApiError(404, "Share not found")
 
@@ -205,7 +184,7 @@ def patch_share(
             share.permission = payload.permission
             changed = True
         if payload.expiryDays is not None:
-            share.expires_at = _expiry_from_days(payload.expiryDays)
+            share.expires_at = expiry_from_days(payload.expiryDays)
             changed = True
         if not changed:
             raise ApiError(400, "Nothing to update")
@@ -219,8 +198,7 @@ def patch_share(
             "expiresAt": iso(share.expires_at),
         }
 
-    status, body = run_idempotent(db, user.id, f"shares-patch-{file_id}-{principal}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"shares-patch-{file_id}-{principal}", idempotency_key, action)
 
 
 @router.delete("/v2/files/{file_id}/shares/{principal}")
@@ -229,21 +207,13 @@ def delete_share(
     principal: str,
     user: CurrentUser = Depends(get_current_user),
     db: Session = Depends(get_db),
-    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    idempotency_key: str | None = IdempotencyKey,
 ) -> JSONResponse:
     def action() -> tuple[int, dict]:
-        principal_type, principal_value = parse_principal_path(principal)
-        if not principal_type:
-            raise ApiError(400, "Invalid principal format")
+        principal_type, principal_value = _parsed_principal(principal)
         require_owned_file(db, user.id, file_id)
 
-        share = db.execute(
-            select(Share).where(
-                Share.file_id == file_id,
-                Share.principal_type == principal_type,
-                Share.principal_value == principal_value,
-            )
-        ).scalars().first()
+        share = _find_share(db, file_id, principal_type, principal_value)
         if share is None:
             raise ApiError(404, "Share not found")
 
@@ -256,5 +226,4 @@ def delete_share(
             "principalValue": principal_value,
         }
 
-    status, body = run_idempotent(db, user.id, f"shares-delete-{file_id}-{principal}", idempotency_key, action)
-    return JSONResponse(status_code=status, content=body)
+    return idempotent_response(db, user.id, f"shares-delete-{file_id}-{principal}", idempotency_key, action)

--- a/backend/app/routers/shares.py
+++ b/backend/app/routers/shares.py
@@ -14,7 +14,14 @@ from ..models import File, Share
 from ..pagination import page_params, page_response
 from ..permissions import is_valid_permission
 from ..principals import parse_principal_path, user_principals
-from ..schemas import PatchShareRequest, PutShareRequest
+from ..schemas import (
+    DeleteShareOut,
+    FileShareOut,
+    InboundShareOut,
+    PatchShareRequest,
+    PutShareRequest,
+    ShareOut,
+)
 from ..services import active_window, expiry_from_days, require_owned_file
 from ..utils import iso, now_utc
 
@@ -40,18 +47,18 @@ def _find_share(db: Session, file_id: str, principal_type: str, principal_value:
 
 
 def _serialize_inbound(share: Share, file: File) -> dict:
-    return {
-        "fileId": share.file_id,
-        "filename": file.filename,
-        "ownerId": file.owner_id,
-        "ownerEmail": file.owner_email,
-        "permission": share.permission,
-        "principalType": share.principal_type,
-        "principalValue": share.principal_value,
-        "principalDisplay": share.principal_display,
-        "sharedAt": iso(share.shared_at),
-        "expiresAt": iso(share.expires_at),
-    }
+    return InboundShareOut(
+        fileId=share.file_id,
+        filename=file.filename,
+        ownerId=file.owner_id,
+        ownerEmail=file.owner_email,
+        permission=share.permission,
+        principalType=share.principal_type,
+        principalValue=share.principal_value,
+        principalDisplay=share.principal_display,
+        sharedAt=iso(share.shared_at),
+        expiresAt=iso(share.expires_at),
+    ).model_dump()
 
 
 @router.get("/v2/shares/inbound")
@@ -106,14 +113,14 @@ def list_file_shares(
         shares,
         page_size,
         offset,
-        lambda s: {
-            "principalType": s.principal_type,
-            "principalValue": s.principal_value,
-            "principalDisplay": s.principal_display,
-            "permission": s.permission,
-            "sharedAt": iso(s.shared_at),
-            "expiresAt": iso(s.expires_at),
-        },
+        lambda s: FileShareOut(
+            principalType=s.principal_type,
+            principalValue=s.principal_value,
+            principalDisplay=s.principal_display,
+            permission=s.permission,
+            sharedAt=iso(s.shared_at),
+            expiresAt=iso(s.expires_at),
+        ).model_dump(),
     )
 
 
@@ -149,13 +156,13 @@ def put_share(
         share.expires_at = expires_at
         db.flush()
 
-        return 200, {
-            "fileId": file_id,
-            "principalType": principal_type,
-            "principalValue": principal_value,
-            "permission": payload.permission,
-            "expiresAt": iso(expires_at),
-        }
+        return 200, ShareOut(
+            fileId=file_id,
+            principalType=principal_type,
+            principalValue=principal_value,
+            permission=payload.permission,
+            expiresAt=iso(expires_at),
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"shares-put-{file_id}-{principal}", idempotency_key, action)
 
@@ -190,13 +197,13 @@ def patch_share(
             raise ApiError(400, "Nothing to update")
         db.flush()
 
-        return 200, {
-            "fileId": file_id,
-            "principalType": principal_type,
-            "principalValue": principal_value,
-            "permission": share.permission,
-            "expiresAt": iso(share.expires_at),
-        }
+        return 200, ShareOut(
+            fileId=file_id,
+            principalType=principal_type,
+            principalValue=principal_value,
+            permission=share.permission,
+            expiresAt=iso(share.expires_at),
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"shares-patch-{file_id}-{principal}", idempotency_key, action)
 
@@ -219,11 +226,11 @@ def delete_share(
 
         db.delete(share)
         db.flush()
-        return 200, {
-            "message": "Share revoked",
-            "fileId": file_id,
-            "principalType": principal_type,
-            "principalValue": principal_value,
-        }
+        return 200, DeleteShareOut(
+            message="Share revoked",
+            fileId=file_id,
+            principalType=principal_type,
+            principalValue=principal_value,
+        ).model_dump()
 
     return idempotent_response(db, user.id, f"shares-delete-{file_id}-{principal}", idempotency_key, action)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,12 +1,13 @@
-"""Pydantic request models for input validation.
+"""Pydantic models for the JSON contract.
 
-Responses are assembled as plain dicts so we can preserve the exact JSON
-contract the existing React client depends on.
+Request models validate input; the response models further down lock the
+output field names in one place (they are dumped to plain dicts before being
+persisted/replayed by the idempotency layer).
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, EmailStr, Field
 
@@ -51,7 +52,6 @@ class PatchFileRequest(BaseModel):
 
 class CreateFolderRequest(BaseModel):
     name: str | None = None
-    folderName: str | None = None
 
 
 class PatchFolderRequest(BaseModel):
@@ -114,3 +114,159 @@ class AgentOperation(BaseModel):
 
 class AgentApplyRequest(BaseModel):
     operations: list[AgentOperation] = Field(default_factory=list)
+
+
+# --- Response models ----------------------------------------------------------
+#
+# One definition per response shape so routers can't drift apart on field
+# names (files are `filename` everywhere; folders are `name`). Mutating routes
+# build a model and pass `.model_dump()` through the idempotency layer, which
+# persists and replays plain JSON. Endpoints whose key set is conditional
+# (download URLs, archive status) stay hand-assembled in their routers.
+
+
+class MessageOut(BaseModel):
+    message: str
+
+
+class UploadCreateOut(BaseModel):
+    fileId: str
+    uploadUrl: str
+    expiresIn: int
+    status: str
+
+
+class FinalizeOut(BaseModel):
+    fileId: str
+    status: str
+    size: int
+    contentType: str | None
+
+
+class PatchFileOut(BaseModel):
+    message: str
+    fileId: str
+    filename: str
+    parentFolderId: str
+
+
+class DeleteFileOut(BaseModel):
+    message: str
+    fileId: str
+
+
+class ChildFolderOut(BaseModel):
+    type: Literal["folder"] = "folder"
+    folderId: str
+    name: str
+    parentFolderId: str
+    createdAt: str | None
+    updatedAt: str | None
+
+
+class ChildFileOut(BaseModel):
+    type: Literal["file"] = "file"
+    fileId: str
+    filename: str
+    parentFolderId: str
+    size: int
+    contentType: str | None
+    status: str
+    isShared: bool
+    hasPublicLink: bool
+    createdAt: str | None
+    updatedAt: str | None
+
+
+class CreateFolderOut(BaseModel):
+    folderId: str
+    name: str
+    parentFolderId: str
+
+
+class PatchFolderOut(BaseModel):
+    message: str
+    folderId: str
+    name: str
+    parentFolderId: str
+
+
+class DeleteFolderOut(BaseModel):
+    message: str
+    folderId: str
+    recursive: bool
+    deletedFolders: int
+    deletedFiles: int
+
+
+class ShareOut(BaseModel):
+    fileId: str
+    principalType: str
+    principalValue: str
+    permission: str
+    expiresAt: str | None
+
+
+class DeleteShareOut(BaseModel):
+    message: str
+    fileId: str
+    principalType: str
+    principalValue: str
+
+
+class InboundShareOut(BaseModel):
+    fileId: str
+    filename: str
+    ownerId: str
+    ownerEmail: str | None
+    permission: str
+    principalType: str
+    principalValue: str
+    principalDisplay: str | None
+    sharedAt: str | None
+    expiresAt: str | None
+
+
+class FileShareOut(BaseModel):
+    principalType: str
+    principalValue: str
+    principalDisplay: str | None
+    permission: str
+    sharedAt: str | None
+    expiresAt: str | None
+
+
+class PublicLinkCreatedOut(BaseModel):
+    token: str
+    fileId: str
+    filename: str
+    hasPassword: bool
+    downloadCount: int
+    expiresAt: str | None
+
+
+class PublicLinkOut(BaseModel):
+    token: str
+    fileId: str
+    filename: str | None
+    hasPassword: bool
+    downloadCount: int
+    createdAt: str | None
+    updatedAt: str | None
+    expiresAt: str | None
+
+
+class PatchPublicLinkOut(BaseModel):
+    token: str
+    hasPassword: bool
+    expiresAt: str | None
+
+
+class DeletePublicLinkOut(BaseModel):
+    message: str
+    token: str
+
+
+class ArchiveQueuedOut(BaseModel):
+    archiveJobId: str
+    status: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -98,7 +98,11 @@ class AgentChatRequest(BaseModel):
 
 class AgentOperation(BaseModel):
     """One step of an approved reorganization plan. Only the fields relevant to
-    ``tool`` are set; the apply endpoint validates the combination."""
+    ``tool`` are set; ``agent.apply._apply_one`` validates the combination.
+
+    Deliberately NOT a pydantic discriminated union: the imperative checks
+    answer 400 with a descriptive message, which is the wire contract clients
+    (and tests) rely on — a union would turn those into 422 validation errors."""
 
     tool: str
     # create_folder

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -201,14 +201,13 @@ def active_window(column, now: datetime):
 # caller's job — so a failure mid-batch rolls the whole plan back.
 
 
-def create_folder_core(db: Session, owner_id: str, parent_folder_id: str, name: object) -> Folder:
+def create_folder_core(db: Session, owner_id: str, parent_folder_id: str, name: str | None) -> Folder:
     """Create a folder under ``parent_folder_id``. Mirrors the checks in
     ``routers/folders.py:create_folder``."""
     if not folder_exists_for_owner(db, owner_id, parent_folder_id):
         raise ApiError(404, "Parent folder not found")
-    if not is_valid_name(name):
+    if not is_valid_name(name) or name is None:
         raise ApiError(400, "Valid folder name required")
-    assert isinstance(name, str)  # narrowed by is_valid_name
     clean = name.strip()
     if name_conflict(db, owner_id, parent_folder_id, Folder, clean):
         raise ApiError(409, "A folder with that name already exists in destination folder")

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -7,12 +7,14 @@ of duplicated query logic.
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
+from .config import settings
 from .errors import ApiError
 from .models import File, Folder, PublicLink, Share
 from .utils import now_utc
@@ -25,10 +27,6 @@ ROOT_FOLDER_ID = "root"
 
 def get_file(db: Session, file_id: str) -> File | None:
     return db.get(File, file_id)
-
-
-def get_folder(db: Session, folder_id: str) -> Folder | None:
-    return db.get(Folder, folder_id)
 
 
 def require_owned_file(db: Session, user_id: str, file_id: str) -> File:
@@ -64,6 +62,29 @@ def user_storage_usage(db: Session, user_id: str, *, exclude_file_id: str | None
     if exclude_file_id is not None:
         stmt = stmt.where(File.id != exclude_file_id)
     return int(db.scalar(stmt) or 0)
+
+
+def collect_subtree(db: Session, owner_id: str, root_id: str) -> tuple[list[Folder], list[File]]:
+    """BFS the folder tree under ``root_id`` (exclusive of the root itself),
+    returning every owned descendant folder and file. Shared by recursive
+    folder delete and archive collection."""
+    folders: list[Folder] = []
+    files: list[File] = []
+    queue = deque([root_id])
+    while queue:
+        parent_id = queue.popleft()
+        child_folders = db.execute(
+            select(Folder).where(Folder.owner_id == owner_id, Folder.parent_folder_id == parent_id)
+        ).scalars().all()
+        for child in child_folders:
+            folders.append(child)
+            queue.append(child.id)
+        files.extend(
+            db.execute(
+                select(File).where(File.owner_id == owner_id, File.parent_folder_id == parent_id)
+            ).scalars().all()
+        )
+    return folders, files
 
 
 # --- Invariants -------------------------------------------------------------
@@ -107,6 +128,20 @@ def is_descendant_folder(
 
 # --- Shares -----------------------------------------------------------------
 
+def expiry_from_days(days: int | None) -> datetime:
+    """Resolve an ``expiryDays`` payload value (``None`` means the configured
+    default) into an absolute naive-UTC expiry, enforcing the 1–365 range.
+    Shared by the share and public-link routers."""
+    resolved = settings.share_expiry_days if days is None else days
+    try:
+        resolved = int(resolved)
+    except (TypeError, ValueError):
+        raise ApiError(400, "expiryDays must be an integer") from None
+    if resolved < 1 or resolved > 365:
+        raise ApiError(400, "expiryDays must be between 1 and 365")
+    return now_utc() + timedelta(days=resolved)
+
+
 def active_share(
     db: Session, file_id: str, principals: Iterable[tuple[str, str]]
 ) -> Share | None:
@@ -120,7 +155,7 @@ def active_share(
     stmt = select(Share).where(
         Share.file_id == file_id,
         or_(*clauses),
-        _active_window(Share.expires_at, now),
+        active_window(Share.expires_at, now),
     )
     return db.execute(stmt).scalars().first()
 
@@ -134,7 +169,7 @@ def derive_file_flags(db: Session, file_ids: list[str]) -> dict[str, dict[str, b
     now = now_utc()
     shared_ids = db.execute(
         select(Share.file_id)
-        .where(Share.file_id.in_(file_ids), _active_window(Share.expires_at, now))
+        .where(Share.file_id.in_(file_ids), active_window(Share.expires_at, now))
         .distinct()
     ).scalars()
     for fid in shared_ids:
@@ -142,7 +177,7 @@ def derive_file_flags(db: Session, file_ids: list[str]) -> dict[str, dict[str, b
 
     linked_ids = db.execute(
         select(PublicLink.file_id)
-        .where(PublicLink.file_id.in_(file_ids), _active_window(PublicLink.expires_at, now))
+        .where(PublicLink.file_id.in_(file_ids), active_window(PublicLink.expires_at, now))
         .distinct()
     ).scalars()
     for fid in linked_ids:
@@ -151,7 +186,8 @@ def derive_file_flags(db: Session, file_ids: list[str]) -> dict[str, dict[str, b
     return flags
 
 
-def _active_window(column, now: datetime):
+def active_window(column, now: datetime):
+    """SQL predicate for "not expired": a null expiry never expires."""
     return or_(column.is_(None), column > now)
 
 

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -30,22 +30,21 @@ def get_file(db: Session, file_id: str) -> File | None:
 
 
 def require_owned_file(db: Session, user_id: str, file_id: str) -> File:
+    """Another tenant's file answers 404, not 403, so the API never confirms
+    that a guessed id exists."""
     file = db.get(File, file_id)
-    if file is None:
+    if file is None or file.owner_id != user_id:
         raise ApiError(404, "File not found")
-    if file.owner_id != user_id:
-        raise ApiError(403, "Access denied")
     return file
 
 
 def require_owned_folder(db: Session, user_id: str, folder_id: str) -> Folder:
+    """Cross-tenant access hides existence (404), matching ``require_owned_file``."""
     if folder_id == ROOT_FOLDER_ID:
         raise ApiError(400, "Root folder cannot be modified")
     folder = db.get(Folder, folder_id)
-    if folder is None:
+    if folder is None or folder.owner_id != user_id:
         raise ApiError(404, "Folder not found")
-    if folder.owner_id != user_id:
-        raise ApiError(403, "Access denied")
     return folder
 
 

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -8,7 +8,6 @@ resolved underneath the storage root to defend against traversal.
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 from .config import settings
@@ -55,7 +54,3 @@ def delete(key: str) -> None:
         pass
     except OSError:
         pass
-
-
-def remove_user_tree() -> None:  # pragma: no cover - maintenance helper
-    shutil.rmtree(settings.storage_dir, ignore_errors=True)

--- a/backend/tests/test_agent_apply.py
+++ b/backend/tests/test_agent_apply.py
@@ -148,7 +148,7 @@ def test_apply_foreign_node_denied(client):
 
     ops = [{"tool": "rename_node", "nodeType": "file", "id": fid, "newName": "x.txt"}]
     resp = client.post("/v2/agent/apply", json={"operations": ops}, headers=auth_header(token_b))
-    assert resp.status_code == 403
+    assert resp.status_code == 404, "foreign nodes look nonexistent"
 
 
 def test_apply_validation_errors(client):

--- a/backend/tests/test_agent_apply.py
+++ b/backend/tests/test_agent_apply.py
@@ -25,9 +25,9 @@ def test_apply_create_folder_then_move_file(client):
     assert resp.json()["applied"] == 2
 
     root = _children(client, h)
-    assert not any(i.get("name") == "beach.jpg" for i in root)
+    assert not any(i.get("filename") == "beach.jpg" for i in root)
     photos_id = next(i["folderId"] for i in root if i["type"] == "folder" and i["name"] == "Photos")
-    assert any(i["name"] == "beach.jpg" for i in _children(client, h, photos_id))
+    assert any(i.get("filename") == "beach.jpg" for i in _children(client, h, photos_id))
 
 
 def test_apply_nested_create_then_move(client):
@@ -45,7 +45,7 @@ def test_apply_nested_create_then_move(client):
 
     photos_id = next(i["folderId"] for i in _children(client, h) if i["name"] == "Photos")
     y2026_id = next(i["folderId"] for i in _children(client, h, photos_id) if i["name"] == "2026")
-    assert any(i["name"] == "img.png" for i in _children(client, h, y2026_id))
+    assert any(i.get("filename") == "img.png" for i in _children(client, h, y2026_id))
 
 
 def test_apply_move_folder(client):
@@ -72,7 +72,7 @@ def test_apply_rename_file_and_folder(client):
     ]
     resp = client.post("/v2/agent/apply", json={"operations": ops}, headers=h)
     assert resp.status_code == 200
-    names = {i["name"] for i in _children(client, h)}
+    names = {i["name"] if i["type"] == "folder" else i["filename"] for i in _children(client, h)}
     assert "new.txt" in names and "NewFolder" in names
 
 

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -15,12 +15,12 @@ def test_backup_restore_round_trip(client, tmp_path):
     # Simulate data loss: drop the file (row + blob).
     client.delete(f"/v2/files/{file_id}", headers=auth_header(token))
     before = client.get("/v2/folders/root/children", headers=auth_header(token)).json()["items"]
-    assert "keep.txt" not in {i["name"] for i in before}
+    assert "keep.txt" not in {i["name"] if i["type"] == "folder" else i["filename"] for i in before}
 
     backup.restore_backup(bundle, replace=True)
 
     items = client.get("/v2/folders/root/children", headers=auth_header(token)).json()["items"]
-    assert {"Docs", "keep.txt"} <= {i["name"] for i in items}
+    assert {"Docs", "keep.txt"} <= {i["name"] if i["type"] == "folder" else i["filename"] for i in items}
 
     # Blob bytes came back too.
     dl = client.post(f"/v2/download/files/{file_id}", json={}, headers=auth_header(token)).json()

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -25,7 +25,7 @@ def test_upload_lifecycle_and_listing(client):
     assert final.json()["size"] == 11
 
     listing = client.get("/v2/folders/root/children", headers=headers).json()
-    names = [item["name"] for item in listing["items"]]
+    names = [item["filename"] for item in listing["items"]]
     assert "report.txt" in names
 
 

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -18,7 +18,7 @@ def test_create_nested_and_list(client):
     assert any(i["type"] == "folder" and i["name"] == "Documents" for i in root_items)
 
     child_items = client.get(f"/v2/folders/{child}/children", headers=headers).json()["items"]
-    assert any(i["type"] == "file" and i["name"] == "a.txt" for i in child_items)
+    assert any(i["type"] == "file" and i["filename"] == "a.txt" for i in child_items)
 
 
 def test_non_recursive_delete_blocks_non_empty(client):

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -15,6 +15,11 @@ def _wait_archive(client, token, job_id, timeout=15.0):
     raise AssertionError("archive timed out")
 
 
+def _display_name(item):
+    """Folders expose `name`, files expose `filename`."""
+    return item["name"] if item["type"] == "folder" else item["filename"]
+
+
 def test_full_owner_and_recipient_journey(client):
     owner, owner_id, _ = register_and_login(client)
     recipient, _, recipient_email = register_and_login(client)
@@ -30,7 +35,7 @@ def test_full_owner_and_recipient_journey(client):
     assert client.patch(f"/v2/files/{report}", json={"newName": "annual.txt", "destinationFolderId": docs},
                         headers=oh).status_code == 200
     docs_items = client.get(f"/v2/folders/{docs}/children", headers=oh).json()["items"]
-    assert any(i.get("name") == "annual.txt" for i in docs_items)
+    assert any(i.get("filename") == "annual.txt" for i in docs_items)
 
     # Share with download permission; recipient sees it inbound and downloads it.
     client.put(f"/v2/files/{report}/shares/email:{recipient_email}",
@@ -69,7 +74,7 @@ def test_full_owner_and_recipient_journey(client):
     # Recursively delete the tree; everything is gone.
     deleted = client.delete(f"/v2/folders/{docs}?recursive=true", headers=oh)
     assert deleted.status_code == 200 and deleted.json()["deletedFiles"] == 1
-    remaining = {i["name"] for i in client.get("/v2/folders/root/children", headers=oh).json()["items"]}
+    remaining = {_display_name(i) for i in client.get("/v2/folders/root/children", headers=oh).json()["items"]}
     assert "Docs" not in remaining and "root-note.txt" in remaining
 
 

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -69,7 +69,7 @@ def test_full_owner_and_recipient_journey(client):
 
     # Revoke the share; recipient loses access.
     client.delete(f"/v2/files/{report}/shares/email:{recipient_email}", headers=oh)
-    assert client.post(f"/v2/download/files/{report}", json={}, headers=auth_header(recipient)).status_code == 403
+    assert client.post(f"/v2/download/files/{report}", json={}, headers=auth_header(recipient)).status_code == 404
 
     # Recursively delete the tree; everything is gone.
     deleted = client.delete(f"/v2/folders/{docs}?recursive=true", headers=oh)

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -35,7 +35,7 @@ def test_lazy_pagination_walks_folders_then_files(client):
     folders = [i for i in items if i["type"] == "folder"]
     files = [i for i in items if i["type"] == "file"]
     assert [f["name"] for f in folders] == folder_names              # sorted, all present
-    assert [f["name"] for f in files] == file_names
+    assert [f["filename"] for f in files] == file_names
     # Folders are streamed before files.
     assert items[len(folder_names) - 1]["type"] == "folder"
     assert items[len(folder_names)]["type"] == "file"

--- a/backend/tests/test_router_edges.py
+++ b/backend/tests/test_router_edges.py
@@ -65,7 +65,7 @@ def test_file_delete_requires_owner(client):
     owner, _, _ = register_and_login(client)
     other, _, _ = register_and_login(client)
     fid = upload_file(client, owner, "x.txt")
-    assert client.delete(f"/v2/files/{fid}", headers=auth_header(other)).status_code == 403
+    assert client.delete(f"/v2/files/{fid}", headers=auth_header(other)).status_code == 404
 
 
 # --- folders ----------------------------------------------------------------
@@ -108,9 +108,9 @@ def test_public_link_admin_edges(client):
     token = client.post(f"/v2/files/{fid}/public-links", json={}, headers=auth_header(owner)).json()["token"]
 
     assert client.patch(f"/v2/public-links/{token}", json={}, headers=auth_header(owner)).status_code == 400
-    assert client.patch(f"/v2/public-links/{token}", json={"expiryDays": 1}, headers=auth_header(other)).status_code == 403
+    assert client.patch(f"/v2/public-links/{token}", json={"expiryDays": 1}, headers=auth_header(other)).status_code == 404
     assert client.delete("/v2/public-links/ghost", headers=auth_header(owner)).status_code == 404
-    assert client.post(f"/v2/files/{fid}/public-links", json={}, headers=auth_header(other)).status_code == 403
+    assert client.post(f"/v2/files/{fid}/public-links", json={}, headers=auth_header(other)).status_code == 404
 
 
 def test_public_download_edges(client):
@@ -151,7 +151,7 @@ def test_download_edges(client):
 
     assert client.post("/v2/download/files/ghost", json={}, headers=h).status_code == 404
     fid = upload_file(client, owner, "d.txt", content=b"data")
-    assert client.post(f"/v2/download/files/{fid}", json={}, headers=auth_header(other)).status_code == 403
+    assert client.post(f"/v2/download/files/{fid}", json={}, headers=auth_header(other)).status_code == 404
 
     # Remove the blob from disk -> 404 from storage.
     db = SessionLocal()
@@ -161,6 +161,22 @@ def test_download_edges(client):
         db.close()
     storage.delete(key)
     assert client.post(f"/v2/download/files/{fid}", json={}, headers=h).status_code == 404
+
+
+def test_download_of_unfinalized_upload_is_conflict(client):
+    """Uploaded bytes that never went through finalize (antivirus + quota
+    re-check) must not become downloadable as a side effect of asking."""
+    owner, _, _ = register_and_login(client)
+    h = auth_header(owner)
+    init = client.post(
+        "/v2/files/uploads",
+        json={"filename": "pending.txt", "contentType": "text/plain", "size": 4},
+        headers=h,
+    ).json()
+    assert client.put(init["uploadUrl"].replace("http://testserver", ""), content=b"data").status_code == 200
+
+    resp = client.post(f"/v2/download/files/{init['fileId']}", json={}, headers=h)
+    assert resp.status_code == 409
 
 
 # --- blobs ------------------------------------------------------------------

--- a/backend/tests/test_shares_and_download.py
+++ b/backend/tests/test_shares_and_download.py
@@ -6,9 +6,9 @@ def test_share_grants_download_by_email(client):
     recipient_token, _, recipient_email = register_and_login(client)
     file_id = upload_file(client, owner_token, "shared.txt", content=b"secret")
 
-    # No share yet -> denied
+    # No share yet -> the file looks nonexistent
     denied = client.post(f"/v2/download/files/{file_id}", json={}, headers=auth_header(recipient_token))
-    assert denied.status_code == 403
+    assert denied.status_code == 404
 
     # Read-only share still cannot download
     client.put(

--- a/backend/tests/test_unit_services.py
+++ b/backend/tests/test_unit_services.py
@@ -49,7 +49,7 @@ def test_require_owned_file(db):
     assert e1.value.status_code == 404
     with pytest.raises(ApiError) as e2:
         services.require_owned_file(db, "other", "f1")
-    assert e2.value.status_code == 403
+    assert e2.value.status_code == 404, "cross-tenant access hides existence"
 
 
 def test_require_owned_folder(db):
@@ -63,7 +63,7 @@ def test_require_owned_folder(db):
     assert nf.value.status_code == 404
     with pytest.raises(ApiError) as denied:
         services.require_owned_folder(db, "other", "d1")
-    assert denied.value.status_code == 403
+    assert denied.value.status_code == 404, "cross-tenant access hides existence"
     assert services.require_owned_folder(db, "u1", "d1").id == "d1"
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,11 +51,10 @@ import {
   renameFolderResult,
   shareFileResult
 } from './service/driveService';
-import type { DriveFolder } from './components/Folder';
+import type { DriveFolder } from './types/drive';
 import type {
   DriveFile,
   DriveListRow,
-  FileGridRow,
   ContextMenuTarget,
   ContextMenuPosition,
   RenameTarget,
@@ -64,8 +63,7 @@ import type {
   SharePermission,
   SharedFile
 } from './types/drive';
-import { toFileGridRow } from './types/drive';
-import { FileColumnsFactory, ListColumnsFactory } from './components/FileColumns';
+import { ListColumnsFactory } from './components/FileColumns';
 import { GridLayout, type GridSize } from './components/GridLayout';
 import { ListLayout } from './components/ListLayout';
 import { ContextMenu } from './components/ContextMenu';
@@ -630,19 +628,6 @@ function App(): JSX.Element {
       createdAt: ''
     } as DriveFile);
   };
-
-  const rows: FileGridRow[] = useMemo(
-    () => files.map((file) => toFileGridRow(file)),
-    [files]
-  );
-
-  const columns = useMemo(
-    () => FileColumnsFactory.create({
-      onDownload: handleDownload,
-      onDelete: handleDelete
-    }),
-    [handleDownload, handleDelete]
-  );
 
   const listRows: DriveListRow[] = useMemo(() => {
     const folderRows: DriveListRow[] = folders.map((f) => ({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,6 @@ import {
   ListItemIcon,
   ListItemText,
   Paper,
-  Snackbar,
   Stack,
   Tab,
   Tabs,
@@ -85,6 +84,9 @@ import { useDriveActions } from './hooks/useDriveActions';
 import { useUploadManager } from './hooks/useUploadManager';
 import { useFileAccessHistory, type FileAccessRecord } from './hooks/useFileAccessHistory';
 import './App.css';
+import { partitionSelection } from './service/selection';
+import SuccessToast from './components/SuccessToast';
+import { formatDate } from './utils';
 
 type ViewMode = 'grid' | 'list';
 type DriveTab = 'my-drive' | 'shared-with-me';
@@ -428,17 +430,13 @@ function App(): JSX.Element {
     const items: MoveItem[] = [];
 
     if (selectedItems.size > 1) {
-      Array.from(selectedItems).forEach((id) => {
-        const file = files.find((f) => f.fileId === id);
-        if (file) {
-          items.push({ type: 'file', id: file.fileId, name: file.filename });
-          return;
-        }
-        const folder = folders.find((f) => f.folderId === id);
-        if (folder) {
-          items.push({ type: 'folder', id: folder.folderId, path: folder.path, name: folder.name });
-        }
-      });
+      const selection = partitionSelection(selectedItems, files, folders);
+      for (const file of selection.files) {
+        items.push({ type: 'file', id: file.fileId, name: file.filename });
+      }
+      for (const folder of selection.folders) {
+        items.push({ type: 'folder', id: folder.folderId, path: folder.path, name: folder.name });
+      }
     } else if (ctxTarget) {
       if (ctxTarget.type === 'file') {
         items.push({ type: 'file', id: ctxTarget.file.fileId, name: ctxTarget.file.filename });
@@ -1198,7 +1196,7 @@ function App(): JSX.Element {
                                   sx={{ height: 20, fontSize: '0.7rem' }}
                                 />
                                 <Typography component="span" variant="caption" color="text.secondary">
-                                  Expires: {new Date(sf.expiresAt).toLocaleDateString()}
+                                  Expires: {formatDate(sf.expiresAt)}
                                 </Typography>
                               </Stack>
                             }
@@ -1291,21 +1289,7 @@ function App(): JSX.Element {
             onDownload={handleDownload}
           />
 
-          <Snackbar
-            open={!!shareSuccess}
-            autoHideDuration={3000}
-            onClose={() => setShareSuccess('')}
-            anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-          >
-            <Alert
-              onClose={() => setShareSuccess('')}
-              severity="success"
-              variant="filled"
-              sx={{ width: '100%' }}
-            >
-              {shareSuccess}
-            </Alert>
-          </Snackbar>
+          <SuccessToast message={shareSuccess} onClose={() => setShareSuccess('')} />
 
           {assistantConfigured && <Assistant onApplied={() => loadFiles()} />}
       </Box>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -125,28 +125,64 @@ type PagedItems<T> = {
   nextCursor?: string | null;
 };
 
-interface V2FolderChildItem {
-  type?: 'file' | 'folder';
-  fileId?: string;
+// Folder-children items are a discriminated union: folders expose `name`,
+// files expose `filename` (matching the backend's ChildFolderOut/ChildFileOut).
+interface V2ChildFolder {
+  type: 'folder';
   folderId?: string;
   name?: string;
-  size?: number;
+  parentFolderId?: string;
   createdAt?: string;
   updatedAt?: string;
-  sharedAt?: string;
+}
+
+interface V2ChildFile {
+  type: 'file';
+  fileId?: string;
+  filename?: string;
+  parentFolderId?: string;
+  size?: number;
+  contentType?: string;
+  status?: string;
+  isShared?: boolean;
+  hasPublicLink?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+type V2FolderChild = V2ChildFolder | V2ChildFile;
+
+interface V2InboundShareItem {
+  fileId?: string;
+  filename?: string;
+  ownerId?: string;
+  ownerEmail?: string;
   permission?: string;
-  hasPassword?: boolean;
-  downloadCount?: number;
-  expiresAt?: string;
   principalType?: string;
   principalValue?: string;
   principalDisplay?: string;
-  ownerId?: string;
-  ownerEmail?: string;
-  filename?: string;
+  sharedAt?: string;
+  expiresAt?: string;
+}
+
+interface V2FileShareItem {
+  principalType?: string;
+  principalValue?: string;
+  principalDisplay?: string;
+  permission?: string;
+  sharedAt?: string;
+  expiresAt?: string;
+}
+
+interface V2PublicLinkItem {
   token?: string;
-  isShared?: boolean;
-  hasPublicLink?: boolean;
+  fileId?: string;
+  filename?: string;
+  hasPassword?: boolean;
+  downloadCount?: number;
+  createdAt?: string;
+  updatedAt?: string;
+  expiresAt?: string;
 }
 
 interface V2ArchiveCreateResult extends ApiResult {
@@ -258,19 +294,19 @@ function principalPath(value: string): string {
   return raw.includes('@') ? `email:${raw}` : `user_sub:${raw}`;
 }
 
-async function listFolderChildrenById(folderId: string, cursor?: string): Promise<PagedItems<V2FolderChildItem>> {
+async function listFolderChildrenById(folderId: string, cursor?: string): Promise<PagedItems<V2FolderChild>> {
   const query = new URLSearchParams();
   query.set('limit', '200');
   if (cursor) query.set('cursor', cursor);
 
-  return DriveApiClient.authRequest<PagedItems<V2FolderChildItem>>(
+  return DriveApiClient.authRequest<PagedItems<V2FolderChild>>(
     `/v2/folders/${encodeURIComponent(folderId)}/children?${query.toString()}`,
     'GET'
   );
 }
 
-async function listAllFolderChildren(folderId: string): Promise<V2FolderChildItem[]> {
-  const out: V2FolderChildItem[] = [];
+async function listAllFolderChildren(folderId: string): Promise<V2FolderChild[]> {
+  const out: V2FolderChild[] = [];
   let cursor: string | undefined;
 
   do {
@@ -298,7 +334,9 @@ async function resolveFolderIdByPath(path?: string): Promise<string> {
 
   for (const segment of segments) {
     const children = await listAllFolderChildren(currentId);
-    const folder = children.find((item) => item.type === 'folder' && item.name === segment);
+    const folder = children.find(
+      (item): item is V2ChildFolder => item.type === 'folder' && item.name === segment
+    );
     if (!folder?.folderId) {
       throw new Error(`Folder not found: ${normalizedPath}`);
     }
@@ -330,10 +368,10 @@ export const listFiles = async (folder?: string): Promise<ListFilesResult> => {
   const items = await listAllFolderChildren(folderId);
 
   const files = items
-    .filter((item) => item.type === 'file' && item.fileId && item.name)
+    .filter((item): item is V2ChildFile => item.type === 'file' && Boolean(item.fileId) && Boolean(item.filename))
     .map((item) => ({
       fileId: item.fileId as string,
-      filename: item.name as string,
+      filename: item.filename as string,
       size: Number(item.size ?? 0),
       createdAt: (item.createdAt || item.updatedAt || '') as string,
       isShared: Boolean(item.isShared),
@@ -341,7 +379,7 @@ export const listFiles = async (folder?: string): Promise<ListFilesResult> => {
     }));
 
   const folders = items
-    .filter((item) => item.type === 'folder' && item.folderId && item.name)
+    .filter((item): item is V2ChildFolder => item.type === 'folder' && Boolean(item.folderId) && Boolean(item.name))
     .map((item) => {
       const pathValue = joinChildPath(currentPath, item.name as string);
       folderPathCache.set(pathValue, item.folderId as string);
@@ -561,7 +599,7 @@ export const renameFolder = async (folderPath: string, newName: string): Promise
 export const listSharedWithMe = async (): Promise<SharedWithMeResult> => {
   const files: SharedWithMeResult['files'] = [];
 
-  await fetchAllPages<V2FolderChildItem>(
+  await fetchAllPages<V2InboundShareItem>(
     (cursor) => {
       const query = new URLSearchParams();
       query.set('limit', '200');
@@ -573,7 +611,7 @@ export const listSharedWithMe = async (): Promise<SharedWithMeResult> => {
         fileId: String(item.fileId || ''),
         sharedBy: String(item.ownerId || ''),
         sharedByEmail: String(item.ownerEmail || ''),
-        filename: String(item.filename || item.name || ''),
+        filename: String(item.filename || ''),
         permission: String(item.permission || 'read'),
         expiresAt: String(item.expiresAt || ''),
       });
@@ -613,7 +651,7 @@ export const shareFile = async (
 export const listFileShares = async (fileId: string): Promise<ListFileSharesResult> => {
   const shares: ListFileSharesResult['shares'] = [];
 
-  await fetchAllPages<V2FolderChildItem>(
+  await fetchAllPages<V2FileShareItem>(
     (cursor) => {
       const query = new URLSearchParams();
       query.set('limit', '200');
@@ -624,7 +662,7 @@ export const listFileShares = async (fileId: string): Promise<ListFileSharesResu
       shares?.push({
         sharedWith: String(item.principalDisplay || item.principalValue || ''),
         permission: String(item.permission || 'read'),
-        sharedAt: String(item.sharedAt || item.createdAt || ''),
+        sharedAt: String(item.sharedAt || ''),
         expiresAt: String(item.expiresAt || ''),
       });
     }
@@ -675,7 +713,7 @@ export const createPublicLink = async (
 export const listPublicLinks = async (fileId: string): Promise<ListPublicLinksResult> => {
   const links: NonNullable<ListPublicLinksResult['links']> = [];
 
-  await fetchAllPages<V2FolderChildItem>(
+  await fetchAllPages<V2PublicLinkItem>(
     (cursor) => {
       const query = new URLSearchParams();
       query.set('limit', '200');

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,3 +1,4 @@
+import { joinPath, normalizePath } from './service/paths';
 import { config } from './config';
 import { getToken } from './auth';
 
@@ -273,19 +274,6 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function normalizePath(path?: string): string {
-  if (!path || path === '/') return '/';
-  const trimmed = path.trim();
-  if (!trimmed) return '/';
-  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
-  const normalized = withLeadingSlash.replace(/\/+/g, '/').replace(/\/$/, '');
-  return normalized || '/';
-}
-
-function joinChildPath(parentPath: string, childName: string): string {
-  return parentPath === '/' ? `/${childName}` : `${parentPath}/${childName}`;
-}
-
 function principalPath(value: string): string {
   const raw = value.trim();
   if (raw.startsWith('email:') || raw.startsWith('user_sub:')) {
@@ -294,27 +282,20 @@ function principalPath(value: string): string {
   return raw.includes('@') ? `email:${raw}` : `user_sub:${raw}`;
 }
 
-async function listFolderChildrenById(folderId: string, cursor?: string): Promise<PagedItems<V2FolderChild>> {
+/** Build a paginated route: full pages of 200 plus the opaque cursor. */
+function pagedRoute(base: string, cursor?: string): string {
   const query = new URLSearchParams();
   query.set('limit', '200');
   if (cursor) query.set('cursor', cursor);
-
-  return DriveApiClient.authRequest<PagedItems<V2FolderChild>>(
-    `/v2/folders/${encodeURIComponent(folderId)}/children?${query.toString()}`,
-    'GET'
-  );
+  return `${base}?${query.toString()}`;
 }
 
 async function listAllFolderChildren(folderId: string): Promise<V2FolderChild[]> {
   const out: V2FolderChild[] = [];
-  let cursor: string | undefined;
-
-  do {
-    const page = await listFolderChildrenById(folderId, cursor);
-    if (Array.isArray(page.items)) out.push(...page.items);
-    cursor = page.nextCursor || undefined;
-  } while (cursor);
-
+  await fetchAllPages<V2FolderChild>(
+    (cursor) => pagedRoute(`/v2/folders/${encodeURIComponent(folderId)}/children`, cursor),
+    (item) => out.push(item)
+  );
   return out;
 }
 
@@ -341,7 +322,7 @@ async function resolveFolderIdByPath(path?: string): Promise<string> {
       throw new Error(`Folder not found: ${normalizedPath}`);
     }
     currentId = folder.folderId;
-    currentPath = joinChildPath(currentPath, segment);
+    currentPath = joinPath(currentPath, segment);
     folderPathCache.set(currentPath, currentId);
   }
 
@@ -381,7 +362,7 @@ export const listFiles = async (folder?: string): Promise<ListFilesResult> => {
   const folders = items
     .filter((item): item is V2ChildFolder => item.type === 'folder' && Boolean(item.folderId) && Boolean(item.name))
     .map((item) => {
-      const pathValue = joinChildPath(currentPath, item.name as string);
+      const pathValue = joinPath(currentPath, item.name as string);
       folderPathCache.set(pathValue, item.folderId as string);
       return {
         folderId: item.folderId as string,
@@ -404,7 +385,7 @@ export const createFolder = async (folderName: string, path?: string): Promise<C
   }>(`/v2/folders/${encodeURIComponent(parentFolderId)}/folders`, 'POST', { name: folderName });
 
   const createdName = result.name ?? folderName;
-  const createdPath = joinChildPath(parentPath, createdName);
+  const createdPath = joinPath(parentPath, createdName);
   if (result.folderId) folderPathCache.set(createdPath, result.folderId);
 
   return {
@@ -600,12 +581,7 @@ export const listSharedWithMe = async (): Promise<SharedWithMeResult> => {
   const files: SharedWithMeResult['files'] = [];
 
   await fetchAllPages<V2InboundShareItem>(
-    (cursor) => {
-      const query = new URLSearchParams();
-      query.set('limit', '200');
-      if (cursor) query.set('cursor', cursor);
-      return `/v2/shares/inbound?${query.toString()}`;
-    },
+    (cursor) => pagedRoute('/v2/shares/inbound', cursor),
     (item) => {
       files?.push({
         fileId: String(item.fileId || ''),
@@ -652,12 +628,7 @@ export const listFileShares = async (fileId: string): Promise<ListFileSharesResu
   const shares: ListFileSharesResult['shares'] = [];
 
   await fetchAllPages<V2FileShareItem>(
-    (cursor) => {
-      const query = new URLSearchParams();
-      query.set('limit', '200');
-      if (cursor) query.set('cursor', cursor);
-      return `/v2/files/${encodeURIComponent(fileId)}/shares?${query.toString()}`;
-    },
+    (cursor) => pagedRoute(`/v2/files/${encodeURIComponent(fileId)}/shares`, cursor),
     (item) => {
       shares?.push({
         sharedWith: String(item.principalDisplay || item.principalValue || ''),
@@ -714,12 +685,7 @@ export const listPublicLinks = async (fileId: string): Promise<ListPublicLinksRe
   const links: NonNullable<ListPublicLinksResult['links']> = [];
 
   await fetchAllPages<V2PublicLinkItem>(
-    (cursor) => {
-      const query = new URLSearchParams();
-      query.set('limit', '200');
-      if (cursor) query.set('cursor', cursor);
-      return `/v2/files/${encodeURIComponent(fileId)}/public-links?${query.toString()}`;
-    },
+    (cursor) => pagedRoute(`/v2/files/${encodeURIComponent(fileId)}/public-links`, cursor),
     (item) => {
       links.push({
         token: String(item.token || ''),

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -15,7 +15,6 @@ import VisibilityRoundedIcon from '@mui/icons-material/VisibilityRounded';
 import type { ContextMenuTarget, ContextMenuPosition } from '../types/drive';
 import { previewKind } from '../service/fileUtils';
 
-export type { ContextMenuTarget, ContextMenuPosition } from '../types/drive';
 
 export interface ContextMenuProps {
   target: ContextMenuTarget;

--- a/frontend/src/components/File.tsx
+++ b/frontend/src/components/File.tsx
@@ -11,10 +11,6 @@ import {
 } from '@mui/material';
 import type { DriveFile } from '../types/drive';
 
-// Re-export types so existing `import from './File'` still resolves
-export type { DriveFile, FileShape, FileGridRow, DriveListRow } from '../types/drive';
-export { driveFileFromUnknown, formatFileSize, toFileGridRow } from '../types/drive';
-
 // ---------------------------------------------------------------------------
 // Row components
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/FileColumns.tsx
+++ b/frontend/src/components/FileColumns.tsx
@@ -12,7 +12,7 @@ import type {
   GridSortCellParams
 } from '@mui/x-data-grid';
 import { getExtension } from '../service/fileUtils';
-import type { DriveFile, DriveFolder, FileGridRow, DriveListRow } from '../types/drive';
+import type { DriveFile, DriveFolder, DriveListRow } from '../types/drive';
 import { formatFileSize } from '../types/drive';
 import { FileItem, FileActions } from './File';
 import { FolderItem } from './Folder';
@@ -36,11 +36,6 @@ function DateChipCell({ date }: { date: string }): React.ReactElement {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-interface FileColumnFactoryInput {
-  onDownload: (file: DriveFile) => void;
-  onDelete: (file: DriveFile) => void;
-}
 
 interface ListColumnFactoryInput {
   onDownload: (file: DriveFile) => void;
@@ -75,70 +70,6 @@ function listRowSortFoldersLast(
 // ---------------------------------------------------------------------------
 // Column factories
 // ---------------------------------------------------------------------------
-
-export class FileColumnsFactory {
-  public static create(input: FileColumnFactoryInput): GridColDef<FileGridRow>[] {
-    return [
-      {
-        field: 'filename',
-        headerName: 'File',
-        flex: 1.6,
-        sortable: true,
-        valueGetter: (params) => params.row.file.filename,
-        renderCell: (params: GridRenderCellParams<FileGridRow>) => (
-          <FileItem file={params.row.file} />
-        )
-      },
-      {
-        field: 'fileextension',
-        headerName: 'Extension',
-        flex: 0.45,
-        sortable: true,
-        valueGetter: (params) => getExtension(params.row.file.filename) ?? 'Unknown',
-        renderCell: (params: GridRenderCellParams<FileGridRow>) => (
-          <ChipCell label={params.value ?? 'Unknown'} />
-        )
-      },
-      {
-        field: 'size',
-        headerName: 'Size',
-        flex: 0.45,
-        type: 'number',
-        valueGetter: (params) => params.row.file.size,
-        renderCell: (params: GridRenderCellParams<FileGridRow>) => (
-          <OutlinedChipCell label={formatFileSize(params.row.file.size)} />
-        )
-      },
-      {
-        field: 'date',
-        headerName: 'Date',
-        width: 140,
-        type: 'dateTime',
-        valueGetter: (params) => new Date(params.row.file.createdAt),
-        renderCell: (params: GridRenderCellParams<FileGridRow>) => (
-          <DateChipCell date={params.row.file.createdAt} />
-        )
-      },
-      {
-        field: 'actions',
-        headerName: 'Actions',
-        width: 130,
-        sortable: false,
-        filterable: false,
-        disableColumnMenu: true,
-        align: 'right',
-        headerAlign: 'right',
-        renderCell: (params: GridRenderCellParams<FileGridRow>) => (
-          <FileActions
-            file={params.row.file}
-            onDownload={input.onDownload}
-            onDelete={input.onDelete}
-          />
-        )
-      }
-    ];
-  }
-}
 
 export class ListColumnsFactory {
   /** Columns for unified list (folders + files). */

--- a/frontend/src/components/Folder.tsx
+++ b/frontend/src/components/Folder.tsx
@@ -5,9 +5,6 @@ import FolderRoundedIcon from '@mui/icons-material/FolderRounded';
 import { IconButton, Stack, Tooltip, Typography } from '@mui/material';
 import type { DriveFolder } from '../types/drive';
 
-// Re-export so existing `import from './Folder'` still resolves
-export type { DriveFolder } from '../types/drive';
-
 export interface FolderItemProps {
   folder: DriveFolder;
 }

--- a/frontend/src/components/GridLayout.tsx
+++ b/frontend/src/components/GridLayout.tsx
@@ -19,6 +19,7 @@ import { FolderIcon, FolderActions } from './Folder';
 import { DynamicRenderedIcon } from './DynamicRenderedIcon';
 import { ImageThumbnail } from './ImageThumbnail';
 import { isImageFilename } from '../service/fileUtils';
+import { formatDate } from '../utils';
 
 export type GridSize = 'small' | 'medium' | 'large';
 
@@ -256,7 +257,7 @@ export function GridLayout({
                 color="text.secondary"
                 sx={{ mt: 0.25 }}
               >
-                {new Date(folder.createdAt).toLocaleDateString()}
+                {formatDate(folder.createdAt)}
               </Typography>
             )}
           </CardActionArea>

--- a/frontend/src/components/MoveDialog.tsx
+++ b/frontend/src/components/MoveDialog.tsx
@@ -21,7 +21,6 @@ import { listFiles } from '../api';
 import type { DriveFolder, MoveItem } from '../types/drive';
 import { parseFolder } from '../service/driveService';
 
-export type { MoveItem } from '../types/drive';
 
 export interface MoveDialogProps {
   open: boolean;

--- a/frontend/src/components/PublicDownloadPage.tsx
+++ b/frontend/src/components/PublicDownloadPage.tsx
@@ -18,6 +18,7 @@ import TimerOffRoundedIcon from '@mui/icons-material/TimerOffRounded';
 import type { PublicLinkInfo } from '../types/drive';
 import { formatFileSize } from '../types/drive';
 import { fetchPublicLinkInfo, getPublicDownloadUrl } from '../service/driveService';
+import { formatDate } from '../utils';
 
 interface PublicDownloadPageProps {
   token: string;
@@ -188,7 +189,7 @@ export function PublicDownloadPage({ token }: PublicDownloadPageProps): React.Re
               </Stack>
               {info.expiresAt && (
                 <Typography variant="body2" color="text.secondary">
-                  Expires: {new Date(info.expiresAt).toLocaleDateString()}
+                  Expires: {formatDate(info.expiresAt)}
                 </Typography>
               )}
             </Stack>

--- a/frontend/src/components/RenameDialog.tsx
+++ b/frontend/src/components/RenameDialog.tsx
@@ -9,7 +9,6 @@ import {
 } from '@mui/material';
 import type { RenameTarget } from '../types/drive';
 
-export type { RenameTarget } from '../types/drive';
 
 export interface RenameDialogProps {
   target: RenameTarget;

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -45,7 +45,6 @@ import {
   updatePublicLinkResult,
 } from '../service/driveService';
 
-export type { ShareTarget, SharePermission } from '../types/drive';
 
 export interface ShareDialogProps {
   target: ShareTarget;

--- a/frontend/src/components/ShareDialog.tsx
+++ b/frontend/src/components/ShareDialog.tsx
@@ -18,7 +18,6 @@ import {
   ListItemText,
   MenuItem,
   Select,
-  Snackbar,
   Stack,
   Switch,
   Tab,
@@ -34,6 +33,8 @@ import AddLinkRoundedIcon from '@mui/icons-material/AddLinkRounded';
 import DownloadRoundedIcon from '@mui/icons-material/DownloadRounded';
 import LockRoundedIcon from '@mui/icons-material/LockRounded';
 import type { ShareTarget, SharePermission, FileShare, PublicLink } from '../types/drive';
+import { formatDate } from '../utils';
+import SuccessToast from './SuccessToast';
 import {
   fetchFileShares,
   revokeShare,
@@ -398,7 +399,7 @@ export function ShareDialog({
                               </Select>
                             </FormControl>
                             <Typography component="span" variant="caption" color="text.secondary">
-                              Expires: {new Date(share.expiresAt).toLocaleDateString()}
+                              Expires: {formatDate(share.expiresAt)}
                             </Typography>
                           </Stack>
                         }
@@ -551,7 +552,7 @@ export function ShareDialog({
                                 </Typography>
                               </Stack>
                               <Typography component="span" variant="caption" color="text.secondary">
-                                Expires: {new Date(link.expiresAt).toLocaleDateString()}
+                                Expires: {formatDate(link.expiresAt)}
                               </Typography>
                             </Stack>
                           }
@@ -578,21 +579,7 @@ export function ShareDialog({
         </DialogActions>
       </Dialog>
 
-      <Snackbar
-        open={snackMsg.length > 0}
-        autoHideDuration={2500}
-        onClose={() => setSnackMsg('')}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert
-          onClose={() => setSnackMsg('')}
-          severity="success"
-          variant="filled"
-          sx={{ width: '100%' }}
-        >
-          {snackMsg}
-        </Alert>
-      </Snackbar>
+      <SuccessToast message={snackMsg} onClose={() => setSnackMsg('')} autoHideDuration={2500} />
     </>
   );
 }

--- a/frontend/src/components/SuccessToast.tsx
+++ b/frontend/src/components/SuccessToast.tsx
@@ -1,0 +1,23 @@
+import { Alert, Snackbar } from '@mui/material';
+
+export interface SuccessToastProps {
+  message: string;
+  onClose: () => void;
+  autoHideDuration?: number;
+}
+
+/** The shared bottom-center success snackbar (filled green alert). */
+export default function SuccessToast({ message, onClose, autoHideDuration = 3000 }: SuccessToastProps) {
+  return (
+    <Snackbar
+      open={message.length > 0}
+      autoHideDuration={autoHideDuration}
+      onClose={onClose}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert onClose={onClose} severity="success" variant="filled" sx={{ width: '100%' }}>
+        {message}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/frontend/src/hooks/useDriveActions.ts
+++ b/frontend/src/hooks/useDriveActions.ts
@@ -1,4 +1,6 @@
 import { useCallback } from 'react';
+import { partitionSelection } from '../service/selection';
+import { openInNewTab } from '../utils';
 import type { DriveFile, DriveFolder } from '../types/drive';
 import { deleteFolder } from '../api';
 import {
@@ -52,7 +54,7 @@ export function useDriveActions({
     const url = await getFileDownloadUrl(file.fileId);
     if (url) {
       onFileAccess?.(file);
-      window.open(url, '_blank', 'noopener,noreferrer');
+      openInNewTab(url);
     } else {
       setError('Download failed');
     }
@@ -64,26 +66,16 @@ export function useDriveActions({
     const result = await getBulkDownloadZipUrl([], [folder.path]);
     setLoading(false);
     if (result.downloadUrl) {
-      window.open(result.downloadUrl, '_blank', 'noopener,noreferrer');
+      openInNewTab(result.downloadUrl);
     } else {
       setError(result.error ?? 'Failed to create ZIP');
     }
   }
 
   async function handleBulkDownloadAsZip(): Promise<void> {
-    const fileIds: string[] = [];
-    const folderPaths: string[] = [];
-    for (const id of Array.from(selectedItems)) {
-      const file = files.find((f) => f.fileId === id);
-      if (file) {
-        fileIds.push(file.fileId);
-        continue;
-      }
-      const folder = folders.find((f) => f.folderId === id);
-      if (folder) {
-        folderPaths.push(folder.path);
-      }
-    }
+    const selection = partitionSelection(selectedItems, files, folders);
+    const fileIds = selection.files.map((f) => f.fileId);
+    const folderPaths = selection.folders.map((f) => f.path);
     if (fileIds.length === 0 && folderPaths.length === 0) {
       setError('No files or folders to download');
       return;
@@ -93,7 +85,7 @@ export function useDriveActions({
     const result = await getBulkDownloadZipUrl(fileIds, folderPaths);
     setLoading(false);
     if (result.downloadUrl) {
-      window.open(result.downloadUrl, '_blank', 'noopener,noreferrer');
+      openInNewTab(result.downloadUrl);
     } else {
       setError(result.error ?? 'Failed to create ZIP');
     }
@@ -178,23 +170,17 @@ export function useDriveActions({
     setLoading(true);
     setError('');
     let failCount = 0;
-    const ids = Array.from(selectedItems);
-    for (let i = 0; i < ids.length; i += 1) {
-      const id = ids[i];
-      const file = files.find((f) => f.fileId === id);
-      if (file) {
-        const r = await deleteFileResult(file.fileId);
-        if (!r.success) failCount += 1;
-        continue;
-      }
-      const folder = folders.find((f) => f.folderId === id);
-      if (folder) {
-        try {
-          const r = await deleteFolder(folder.path);
-          if (r.error) failCount += 1;
-        } catch {
-          failCount += 1;
-        }
+    const selection = partitionSelection(selectedItems, files, folders);
+    for (const file of selection.files) {
+      const r = await deleteFileResult(file.fileId);
+      if (!r.success) failCount += 1;
+    }
+    for (const folder of selection.folders) {
+      try {
+        const r = await deleteFolder(folder.path);
+        if (r.error) failCount += 1;
+      } catch {
+        failCount += 1;
       }
     }
     const hasErrors = failCount > 0;
@@ -217,17 +203,13 @@ export function useDriveActions({
       // If multiple items are selected and the dragged item is among them, move all
       const idsToMove: Array<{ type: 'file' | 'folder'; id: string; path?: string }> = [];
       if (selectedItems.has(dragData.id) && selectedItems.size > 1) {
-        Array.from(selectedItems).forEach((id) => {
-          const file = files.find((f) => f.fileId === id);
-          if (file) {
-            idsToMove.push({ type: 'file', id });
-            return;
-          }
-          const folder = folders.find((f) => f.folderId === id);
-          if (folder) {
-            idsToMove.push({ type: 'folder', id, path: folder.path });
-          }
-        });
+        const selection = partitionSelection(selectedItems, files, folders);
+        for (const file of selection.files) {
+          idsToMove.push({ type: 'file', id: file.fileId });
+        }
+        for (const folder of selection.folders) {
+          idsToMove.push({ type: 'folder', id: folder.folderId, path: folder.path });
+        }
       } else {
         if (dragData.type === 'folder') {
           const folder = folders.find((f) => f.folderId === dragData.id);

--- a/frontend/src/hooks/useUploadManager.ts
+++ b/frontend/src/hooks/useUploadManager.ts
@@ -1,5 +1,6 @@
 import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createFolder, uploadFile } from '../api';
+import { normalizePath } from '../service/paths';
 
 const MAX_PARALLEL_UPLOADS = 3;
 
@@ -87,13 +88,6 @@ function createClientId(prefix = 'id'): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function normalizeDrivePath(path: string): string {
-  if (!path) return '/';
-  const normalized = path.replace(/\/+/g, '/').replace(/\/$/, '');
-  if (!normalized || normalized === '/') return '/';
-  return normalized.startsWith('/') ? normalized : `/${normalized}`;
-}
-
 function normalizeRelativePath(relativePath: string): string {
   return relativePath
     .replace(/\\/g, '/')
@@ -103,10 +97,10 @@ function normalizeRelativePath(relativePath: string): string {
 }
 
 function joinDrivePath(basePath: string, relativePath: string): string {
-  const base = normalizeDrivePath(basePath);
+  const base = normalizePath(basePath);
   const relative = normalizeRelativePath(relativePath);
   if (!relative) return base;
-  return normalizeDrivePath(base === '/' ? `/${relative}` : `${base}/${relative}`);
+  return normalizePath(base === '/' ? `/${relative}` : `${base}/${relative}`);
 }
 
 function dirname(relativePath: string): string {
@@ -269,7 +263,7 @@ export function useUploadManager({
 
   const ensureFolderPathExists = useCallback(
     async (targetPath: string, folderCache: Set<string>, signal: AbortSignal): Promise<void> => {
-      const normalizedTarget = normalizeDrivePath(targetPath);
+      const normalizedTarget = normalizePath(targetPath);
       if (normalizedTarget === '/' || folderCache.has(normalizedTarget)) return;
 
       const segments = normalizedTarget.split('/').filter(Boolean);
@@ -307,7 +301,7 @@ export function useUploadManager({
         return;
       }
 
-      const basePath = normalizeDrivePath(destinationPathOverride ?? currentPath);
+      const basePath = normalizePath(destinationPathOverride ?? currentPath);
       setError('');
       setUploadSummary('');
       setUploadItems(

--- a/frontend/src/hooks/useUploadManager.ts
+++ b/frontend/src/hooks/useUploadManager.ts
@@ -66,7 +66,6 @@ interface UseUploadManagerArgs {
 
 interface UseUploadManagerResult {
   fileUploadInputRef: React.MutableRefObject<HTMLInputElement | null>;
-  folderUploadInputRef: React.MutableRefObject<HTMLInputElement | null>;
   uploadItems: UploadItemProgress[];
   uploadStats: UploadStats;
   isUploading: boolean;
@@ -74,9 +73,7 @@ interface UseUploadManagerResult {
   isUploadDragActive: boolean;
   setUploadSummary: React.Dispatch<React.SetStateAction<string>>;
   openFilePicker: () => void;
-  openFolderPicker: () => void;
   handleUploadFiles: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
-  handleUploadFolder: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
   uploadFromDataTransfer: (dataTransfer: DataTransfer, destinationPath?: string) => Promise<void>;
   handleCancelUpload: () => void;
 }
@@ -211,21 +208,12 @@ async function uploadCandidatesFromDrop(dataTransfer: DataTransfer): Promise<Upl
   return candidates;
 }
 
-function uploadCandidatesFromFileList(
-  fileList: FileList,
-  preserveRelativePath: boolean
-): UploadCandidate[] {
-  return Array.from(fileList).map((rawFile) => {
-    const relativePath =
-      preserveRelativePath && rawFile.webkitRelativePath
-        ? normalizeRelativePath(rawFile.webkitRelativePath)
-        : rawFile.name;
-    return {
-      id: createClientId('upload'),
-      file: rawFile,
-      relativePath
-    };
-  });
+function uploadCandidatesFromFileList(fileList: FileList): UploadCandidate[] {
+  return Array.from(fileList).map((rawFile) => ({
+    id: createClientId('upload'),
+    file: rawFile,
+    relativePath: rawFile.name
+  }));
 }
 
 export function useUploadManager({
@@ -240,16 +228,11 @@ export function useUploadManager({
   const [isUploadDragActive, setIsUploadDragActive] = useState(false);
 
   const fileUploadInputRef = useRef<HTMLInputElement | null>(null);
-  const folderUploadInputRef = useRef<HTMLInputElement | null>(null);
   const uploadAbortControllerRef = useRef<AbortController | null>(null);
   const uploadDragDepthRef = useRef(0);
 
   const openFilePicker = useCallback((): void => {
     fileUploadInputRef.current?.click();
-  }, []);
-
-  const openFolderPicker = useCallback((): void => {
-    folderUploadInputRef.current?.click();
   }, []);
 
   const updateUploadItem = useCallback(
@@ -438,20 +421,7 @@ export function useUploadManager({
       if (!selectedFiles || selectedFiles.length === 0) {
         return;
       }
-      const candidates = uploadCandidatesFromFileList(selectedFiles, false);
-      await startUploadBatch(candidates);
-      event.target.value = '';
-    },
-    [startUploadBatch]
-  );
-
-  const handleUploadFolder = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
-      const selectedFiles = event.target.files;
-      if (!selectedFiles || selectedFiles.length === 0) {
-        return;
-      }
-      const candidates = uploadCandidatesFromFileList(selectedFiles, true);
+      const candidates = uploadCandidatesFromFileList(selectedFiles);
       await startUploadBatch(candidates);
       event.target.value = '';
     },
@@ -460,13 +430,6 @@ export function useUploadManager({
 
   const handleCancelUpload = useCallback((): void => {
     uploadAbortControllerRef.current?.abort();
-  }, []);
-
-  useEffect(() => {
-    const folderInput = folderUploadInputRef.current;
-    if (!folderInput) return;
-    folderInput.setAttribute('webkitdirectory', '');
-    folderInput.setAttribute('directory', '');
   }, []);
 
   useEffect(() => {
@@ -558,7 +521,6 @@ export function useUploadManager({
 
   return {
     fileUploadInputRef,
-    folderUploadInputRef,
     uploadItems,
     uploadStats,
     isUploading,
@@ -566,9 +528,7 @@ export function useUploadManager({
     isUploadDragActive,
     setUploadSummary,
     openFilePicker,
-    openFolderPicker,
     handleUploadFiles,
-    handleUploadFolder,
     uploadFromDataTransfer,
     handleCancelUpload
   };

--- a/frontend/src/service/driveService.ts
+++ b/frontend/src/service/driveService.ts
@@ -57,13 +57,31 @@ async function wrapApiCall<T extends { error?: string }>(
   fn: () => Promise<T>,
   fallbackMsg: string
 ): Promise<ApiCallResult> {
+  return wrapApiFetch(
+    fn,
+    (): ApiCallResult => ({ success: true }),
+    (error) => ({ success: false, error }),
+    fallbackMsg
+  );
+}
+
+/**
+ * Shared try/catch + error-field extraction for calls whose result carries
+ * data: `map` shapes the success value, `onError` the failure value.
+ */
+async function wrapApiFetch<T extends { error?: string }, R>(
+  fn: () => Promise<T>,
+  map: (data: T) => R,
+  onError: (message: string) => R,
+  fallbackMsg: string
+): Promise<R> {
   try {
-    const result = await fn();
-    if (result.error) return { success: false, error: result.error };
-    return { success: true };
+    const data = await fn();
+    if (data.error) return onError(data.error);
+    return map(data);
   } catch (err) {
     const message = err instanceof Error ? err.message : fallbackMsg;
-    return { success: false, error: message };
+    return onError(message);
   }
 }
 
@@ -89,27 +107,26 @@ export interface FetchFilesResult {
 }
 
 export async function fetchFiles(folder?: string): Promise<FetchFilesResult> {
-  try {
-    const data = await listFiles(folder);
-    const files = filesFromUnknown(data.files);
-    const folders = Array.isArray(data.folders)
-      ? data.folders.map(parseFolder).filter((f): f is DriveFolder => f !== null)
-      : [];
-    return { files, folders };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load files';
-    return { files: [], folders: [], error: message };
-  }
+  return wrapApiFetch(
+    () => listFiles(folder),
+    (data) => ({
+      files: filesFromUnknown(data.files),
+      folders: Array.isArray(data.folders)
+        ? data.folders.map(parseFolder).filter((f): f is DriveFolder => f !== null)
+        : [],
+    }),
+    (error) => ({ files: [], folders: [], error }),
+    'Failed to load files'
+  );
 }
 
 export async function getFileDownloadUrl(fileId: string): Promise<string | null> {
-  try {
-    const { downloadUrl, error } = await getDownloadUrl(fileId);
-    if (error || !downloadUrl) return null;
-    return downloadUrl;
-  } catch {
-    return null;
-  }
+  return wrapApiFetch(
+    () => getDownloadUrl(fileId),
+    (data) => data.downloadUrl ?? null,
+    () => null,
+    'Download failed'
+  );
 }
 
 export interface BulkDownloadZipResult {
@@ -121,15 +138,12 @@ export async function getBulkDownloadZipUrl(
   fileIds: string[],
   folderPaths: string[]
 ): Promise<BulkDownloadZipResult> {
-  try {
-    const result = await createDownloadZip(fileIds, folderPaths);
-    if (result.error) return { error: result.error };
-    if (!result.downloadUrl) return { error: 'No download URL returned' };
-    return { downloadUrl: result.downloadUrl };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to create ZIP';
-    return { error: message };
-  }
+  return wrapApiFetch(
+    () => createDownloadZip(fileIds, folderPaths),
+    (data) => (data.downloadUrl ? { downloadUrl: data.downloadUrl } : { error: 'No download URL returned' }),
+    (error) => ({ error }),
+    'Failed to create ZIP'
+  );
 }
 
 export interface DeleteFileResult {
@@ -168,21 +182,21 @@ export interface FetchSharedFilesResult {
 }
 
 export async function fetchSharedWithMe(): Promise<FetchSharedFilesResult> {
-  try {
-    const data = await listSharedWithMe();
-    const files: SharedFile[] = (data.files ?? []).map((f) => ({
-      fileId: f.fileId,
-      filename: f.filename,
-      sharedBy: f.sharedBy,
-      sharedByEmail: f.sharedByEmail,
-      permission: f.permission as SharePermission,
-      expiresAt: f.expiresAt
-    }));
-    return { files };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load shared files';
-    return { files: [], error: message };
-  }
+  return wrapApiFetch(
+    () => listSharedWithMe(),
+    (data) => ({
+      files: (data.files ?? []).map((f) => ({
+        fileId: f.fileId,
+        filename: f.filename,
+        sharedBy: f.sharedBy,
+        sharedByEmail: f.sharedByEmail,
+        permission: f.permission as SharePermission,
+        expiresAt: f.expiresAt,
+      })),
+    }),
+    (error) => ({ files: [], error }),
+    'Failed to load shared files'
+  );
 }
 
 export interface ShareResult {
@@ -197,14 +211,12 @@ export async function shareFileResult(
   permission: string,
   expiryDays?: number
 ): Promise<ShareResult> {
-  try {
-    const result = await apiShareFile(fileId, shareWithEmail, permission, expiryDays);
-    if (result.error) return { success: false, error: result.error };
-    return { success: true, expiresAt: result.expiresAt };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Share failed';
-    return { success: false, error: message };
-  }
+  return wrapApiFetch(
+    () => apiShareFile(fileId, shareWithEmail, permission, expiryDays),
+    (data): ShareResult => ({ success: true, expiresAt: data.expiresAt }),
+    (error) => ({ success: false, error }),
+    'Share failed'
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -217,19 +229,19 @@ export interface FetchFileSharesResult {
 }
 
 export async function fetchFileShares(fileId: string): Promise<FetchFileSharesResult> {
-  try {
-    const data = await apiListFileShares(fileId);
-    const shares: FileShare[] = (data.shares ?? []).map((s) => ({
-      sharedWith: s.sharedWith,
-      permission: s.permission as SharePermission,
-      sharedAt: s.sharedAt,
-      expiresAt: s.expiresAt
-    }));
-    return { shares };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load shares';
-    return { shares: [], error: message };
-  }
+  return wrapApiFetch(
+    () => apiListFileShares(fileId),
+    (data) => ({
+      shares: (data.shares ?? []).map((s) => ({
+        sharedWith: s.sharedWith,
+        permission: s.permission as SharePermission,
+        sharedAt: s.sharedAt,
+        expiresAt: s.expiresAt,
+      })),
+    }),
+    (error) => ({ shares: [], error }),
+    'Failed to load shares'
+  );
 }
 
 export interface RevokeShareResult {
@@ -272,23 +284,23 @@ export async function createPublicLinkResult(
   password?: string,
   expiryDays?: number
 ): Promise<CreatePublicLinkResult> {
-  try {
-    const data = await apiCreatePublicLink(fileId, password, expiryDays);
-    if (data.error) return { success: false, error: data.error };
-    const link: PublicLink = {
-      token: data.token ?? '',
-      fileId: data.fileId ?? fileId,
-      filename: data.filename ?? '',
-      hasPassword: data.hasPassword ?? false,
-      downloadCount: data.downloadCount ?? 0,
-      createdAt: data.createdAt ?? '',
-      expiresAt: data.expiresAt ?? '',
-    };
-    return { success: true, link };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to create public link';
-    return { success: false, error: message };
-  }
+  return wrapApiFetch(
+    () => apiCreatePublicLink(fileId, password, expiryDays),
+    (data): CreatePublicLinkResult => ({
+      success: true,
+      link: {
+        token: data.token ?? '',
+        fileId: data.fileId ?? fileId,
+        filename: data.filename ?? '',
+        hasPassword: data.hasPassword ?? false,
+        downloadCount: data.downloadCount ?? 0,
+        createdAt: data.createdAt ?? '',
+        expiresAt: data.expiresAt ?? '',
+      } satisfies PublicLink,
+    }),
+    (error) => ({ success: false, error }),
+    'Failed to create public link'
+  );
 }
 
 export interface FetchPublicLinksResult {
@@ -297,22 +309,22 @@ export interface FetchPublicLinksResult {
 }
 
 export async function fetchPublicLinks(fileId: string): Promise<FetchPublicLinksResult> {
-  try {
-    const data = await apiListPublicLinks(fileId);
-    const links: PublicLink[] = (data.links ?? []).map((l) => ({
-      token: l.token,
-      fileId: l.fileId,
-      filename: l.filename,
-      hasPassword: l.hasPassword,
-      downloadCount: l.downloadCount,
-      createdAt: l.createdAt,
-      expiresAt: l.expiresAt,
-    }));
-    return { links };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Failed to load public links';
-    return { links: [], error: message };
-  }
+  return wrapApiFetch(
+    () => apiListPublicLinks(fileId),
+    (data) => ({
+      links: (data.links ?? []).map((l) => ({
+        token: l.token,
+        fileId: l.fileId,
+        filename: l.filename,
+        hasPassword: l.hasPassword,
+        downloadCount: l.downloadCount,
+        createdAt: l.createdAt,
+        expiresAt: l.expiresAt,
+      })),
+    }),
+    (error) => ({ links: [], error }),
+    'Failed to load public links'
+  );
 }
 
 export interface DeletePublicLinkResult {
@@ -346,22 +358,21 @@ export interface FetchPublicLinkInfoResult {
 }
 
 export async function fetchPublicLinkInfo(token: string): Promise<FetchPublicLinkInfoResult> {
-  try {
-    const data = await apiGetPublicLinkInfo(token);
-    if (data.error) return { error: data.error };
-    const info: PublicLinkInfo = {
-      filename: data.filename ?? '',
-      size: data.size ?? 0,
-      contentType: data.contentType ?? 'application/octet-stream',
-      hasPassword: data.hasPassword ?? false,
-      downloadCount: data.downloadCount ?? 0,
-      expiresAt: data.expiresAt ?? '',
-    };
-    return { info };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Link not found or expired';
-    return { error: message };
-  }
+  return wrapApiFetch(
+    () => apiGetPublicLinkInfo(token),
+    (data): FetchPublicLinkInfoResult => ({
+      info: {
+        filename: data.filename ?? '',
+        size: data.size ?? 0,
+        contentType: data.contentType ?? 'application/octet-stream',
+        hasPassword: data.hasPassword ?? false,
+        downloadCount: data.downloadCount ?? 0,
+        expiresAt: data.expiresAt ?? '',
+      } satisfies PublicLinkInfo,
+    }),
+    (error) => ({ error }),
+    'Link not found or expired'
+  );
 }
 
 export interface PublicDownloadUrlResult {
@@ -373,14 +384,12 @@ export async function getPublicDownloadUrl(
   token: string,
   password?: string
 ): Promise<PublicDownloadUrlResult> {
-  try {
-    const data = await apiDownloadPublicLink(token, password);
-    if (data.error) return { error: data.error };
-    return { downloadUrl: data.downloadUrl };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : 'Download failed';
-    return { error: message };
-  }
+  return wrapApiFetch(
+    () => apiDownloadPublicLink(token, password),
+    (data): PublicDownloadUrlResult => ({ downloadUrl: data.downloadUrl }),
+    (error) => ({ error }),
+    'Download failed'
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/service/paths.ts
+++ b/frontend/src/service/paths.ts
@@ -1,0 +1,19 @@
+/**
+ * Drive-path helpers shared by the API layer and the upload manager, so the
+ * two sides can't disagree on what a normalized path looks like.
+ */
+
+/** Normalize a drive path: leading slash, collapsed slashes, no trailing slash. */
+export function normalizePath(path?: string): string {
+  if (!path || path === '/') return '/';
+  const trimmed = path.trim();
+  if (!trimmed) return '/';
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  const normalized = withLeadingSlash.replace(/\/+/g, '/').replace(/\/$/, '');
+  return normalized || '/';
+}
+
+/** Join a child segment onto an already-normalized parent path. */
+export function joinPath(parentPath: string, childName: string): string {
+  return parentPath === '/' ? `/${childName}` : `${parentPath}/${childName}`;
+}

--- a/frontend/src/service/selection.ts
+++ b/frontend/src/service/selection.ts
@@ -1,0 +1,25 @@
+import type { DriveFile, DriveFolder } from '../types/drive';
+
+/**
+ * Resolve selected ids against the current listing: ids matching a file go to
+ * `files`, ids matching a folder go to `folders`, unknown ids are dropped.
+ * The shared walk behind bulk download, bulk delete, drag-move, and "move to".
+ */
+export function partitionSelection(
+  selectedIds: Iterable<string>,
+  files: DriveFile[],
+  folders: DriveFolder[]
+): { files: DriveFile[]; folders: DriveFolder[] } {
+  const selectedFiles: DriveFile[] = [];
+  const selectedFolders: DriveFolder[] = [];
+  for (const id of selectedIds) {
+    const file = files.find((f) => f.fileId === id);
+    if (file) {
+      selectedFiles.push(file);
+      continue;
+    }
+    const folder = folders.find((f) => f.folderId === id);
+    if (folder) selectedFolders.push(folder);
+  }
+  return { files: selectedFiles, folders: selectedFolders };
+}

--- a/frontend/src/types/drive.ts
+++ b/frontend/src/types/drive.ts
@@ -65,16 +65,6 @@ export function formatFileSize(size: number): string {
 // Grid / List row types
 // ---------------------------------------------------------------------------
 
-export interface FileGridRow {
-  id: string;
-  file: DriveFile;
-}
-
-/** Convert a DriveFile to a grid row. */
-export function toFileGridRow(file: DriveFile): FileGridRow {
-  return { id: file.fileId, file };
-}
-
 /** Unified row for list view: folders and files in one grid. */
 export type DriveListRow =
   | { id: string; type: 'file'; file: DriveFile }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,11 @@
+/** Small shared UI helpers. */
+
+/** Human date (locale) for an ISO timestamp, e.g. expiry lines. */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+/** Open a URL in a new tab without giving it a handle back to this window. */
+export function openInNewTab(url: string): void {
+  window.open(url, '_blank', 'noopener,noreferrer');
+}


### PR DESCRIPTION
## Summary
This PR consolidates error handling patterns across the codebase and introduces explicit response schemas to ensure consistency in API contracts. The changes unify try/catch logic, extract shared utilities, and lock down response field names through Pydantic models.

## Key Changes

### Frontend
- **Unified API error handling**: Introduced `wrapApiFetch()` generic utility to replace repetitive try/catch blocks in `driveService.ts`. The new function accepts a `map` function to shape success responses and an `onError` handler for failures, reducing boilerplate across `fetchFiles()`, `getFileDownloadUrl()`, `getBulkDownloadZipUrl()`, `fetchSharedWithMe()`, `shareFileResult()`, and `fetchFileShares()`.
- **Extracted path utilities**: Moved `normalizePath()` and `joinPath()` to a new `service/paths.ts` module for reuse between the API layer and upload manager.
- **Extracted selection logic**: Created `service/selection.ts` with `partitionSelection()` to resolve selected IDs against file/folder listings, used by bulk download, bulk delete, and move operations.
- **Shared UI components**: Extracted `SuccessToast` component for consistent success notifications across dialogs and actions.
- **Removed unused types**: Deleted `FileGridRow` and `FileColumnsFactory` (grid view was unused); consolidated type exports to `types/drive.ts`.
- **Utility helpers**: Added `utils.ts` with `formatDate()` and `openInNewTab()` for consistent date formatting and link opening.

### Backend
- **Response schema models**: Added comprehensive Pydantic response models (`UploadCreateOut`, `FinalizeOut`, `PatchFileOut`, `DeleteFileOut`, `ChildFolderOut`, `ChildFileOut`, `CreateFolderOut`, `PatchFolderOut`, `DeleteFolderOut`, `ShareOut`, `DeleteShareOut`, `InboundShareOut`, `FileShareOut`, `PublicLinkCreatedOut`, `PublicLinkOut`, `DeletePublicLinkOut`, `MessageOut`) to lock down response field names in one place. Routers now build these models and pass `.model_dump()` through the idempotency layer.
- **Unified idempotency**: Refactored `idempotency.py` to provide `idempotent_response()` wrapper that handles both action execution and response persistence/replay. Updated all mutating routers (`files.py`, `folders.py`, `shares.py`, `public_links.py`, `archive.py`) to use the new pattern with `IdempotencyKey` dependency.
- **Extracted pagination helpers**: Created `page_params()` and `page_response()` in `pagination.py` to standardize cursor-based pagination logic across list endpoints.
- **Extracted service utilities**: Moved `expiry_from_days()` and `active_window()` to `services.py` for reuse across shares and public links routers. Added `collect_subtree()` for recursive folder traversal (used by archive and agent apply).
- **Extracted principal helpers**: Created `user_principals()` in `principals.py` to generate principal clauses for a user (email + user_sub), and `_parsed_principal()` in shares router for consistent principal path parsing.
- **Extracted path utilities**: Created `agent/pathutil.py` with `path_segments()` and `find_child_folder()` shared by agent tools and apply endpoint.
- **Consistent error responses**: Updated `require_owned_file()` and `require_owned_folder()` to return 404 (not 403) for cross-tenant access, preventing API from confirming guessed IDs exist. Updated `_require_owned_link()` in public links to match this pattern.
- **Type safety**: Converted `PrincipalType` to a `Literal` type with `get_args()` for validation, and `SharePermission` to a `Literal` in `permissions.py`.

### Tests
- Updated test expectations to reflect 404 responses for cross-tenant access (was 403).
- Fixed test helpers to use correct field names (`name` for folders, `filename` for files).

https://claude.ai/code/session_01MuZeyz5mYp9cGkSh522F3f